### PR TITLE
Avoid features that require Python >= 3.11

### DIFF
--- a/src/sub.py
+++ b/src/sub.py
@@ -252,11 +252,11 @@ async def get_info(path: str, slice: str = None):
     slice_obj = parse_slice(slice)
     array, schunk = utils.open_b2(abspath)
     if array is not None:
-        array = array[*slice_obj]
+        array = array.__getitem__(*slice_obj)
         array = blosc2.asarray(array)
         metadata = utils.read_metadata(array)
     else:
-        schunk = schunk[*slice_obj]
+        schunk = schunk.__getitem__(*slice_obj)
         schunk = blosc2.asarray(schunk)
         metadata = utils.read_metadata(schunk)
 
@@ -298,11 +298,11 @@ async def get_download(path: str, nchunk: int, slice: str = None):
     # With slice
     if slice is not None:
         if array is not None:
-            array = array[*slice_obj]
+            array = array.__getitem__(*slice_obj)
             array = blosc2.asarray(array)
             schunk = array.schunk
         else:
-            schunk = schunk[*slice_obj]
+            schunk = schunk.__getitem__(*slice_obj)
             schunk = blosc2.asarray(schunk)
 
     # Stream response

--- a/src/utils.py
+++ b/src/utils.py
@@ -173,8 +173,7 @@ def start_client(url):
 async def disconnect_client(client, timeout=5):
     if client is not None:
         # If the broker is down client.disconnect hangs, wo we wrap it in a timeout
-        async with asyncio.timeout(timeout):
-            await client.disconnect()
+        await asyncio.wait_for(client.disconnect(), timeout)
 
 
 #


### PR DESCRIPTION
The features are:

- Get item with unpack sequence syntax for the slice (`array[*slice]`), maybe supported after the adoption of the specializing interpreter (PEP 659).  Use the (uglier) `array.__getitem__(*slice)` instead.

- The `asyncio.timeout()` context manager.  Use `asyncio.await_for()` instead.

Alternatively, the minimum Python version of the package may be bumped from the 3.8 declared in `pyproject.toml` to 3.11, but that would discard some distro versions.