### PR TITLE
Enhance tests for data examples and process control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 /tests/data
 /tests/supervisord.log
 /tests/supervisord.pid
+/tests/var/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 .*.swp
 __pycache__
 
-/tests/data/
+/tests/data
 /tests/supervisord.log
 /tests/supervisord.pid

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,4 @@
 __pycache__
 
 /tests/data
-/tests/supervisord.log
-/tests/supervisord.pid
 /tests/var/

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ And then the tests can be run:
 pytest -v
 ```
 
-You may place your own data files under `tests/data`, otherwise the test publisher will use the files under `root-example`.
+You may place your own data files under `tests/data`, otherwise the test publisher will use the files under `root-example`.  After tests finish, state files will be left under `tests/var` in case you want to inspect them.
 
 
 ## Use with caution

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ And then the tests can be run:
 pytest -v
 ```
 
+You may place your own data files under `tests/data`, otherwise the test publisher will use the files under `root-example`.
+
 
 ## Use with caution
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,18 @@ import time
 
 import pytest
 
+from pathlib import Path
+
 
 
 @pytest.fixture(scope='session')
 def services():
+    tests_dir = Path('tests')
+
+    data_dir = tests_dir / 'data'
+    if not data_dir.is_dir() and not data_dir.is_symlink():
+        data_dir.symlink_to('../root-example', target_is_directory=True)
+
     popen = subprocess.Popen(['supervisord', '-c', 'tests/supervisor.conf'])
     assert popen.wait() == 0
     time.sleep(3.0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,13 @@ import pytest
 from pathlib import Path
 
 
+def supervisor_start(*args, conf=None):
+    return subprocess.check_call([
+        'supervisord',
+        '-c', conf,
+        *args])
+
+
 def supervisor_send(*args, conf=None):
     return subprocess.check_output([
         'supervisorctl',
@@ -51,12 +58,10 @@ def services():
 
     pid_file = var_dir / 'supervisord.pid'
 
-    subprocess.check_call([
-        'supervisord',
-        '-c', conf_file,
-        '-l', var_dir / 'supervisord.log',
-        '-q', logs_dir,
-        '-j', pid_file])
+    supervisor_start('-l', var_dir / 'supervisord.log',
+                     '-q', logs_dir,
+                     '-j', pid_file,
+                     conf=conf_file)
 
     try:
         wait_for_programs(start_timeout_secs,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,12 @@ def services():
         '-q', logs_dir,
         '-j', pid_file])
     time.sleep(3.0)
-    yield
-    pid = int(pid_file.read_text())
-    os.kill(pid, signal.SIGTERM)
+    try:
+        yield
+    finally:
+        try:
+            pid = int(pid_file.read_text())
+        except:
+            pass
+        else:
+            os.kill(pid, signal.SIGTERM)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,11 @@ def services():
     if not data_dir.is_dir() and not data_dir.is_symlink():
         data_dir.symlink_to('../root-example', target_is_directory=True)
 
+    var_dir = tests_dir / 'var'
+
     popen = subprocess.Popen(['supervisord', '-c', tests_dir / 'supervisor.conf'])
     assert popen.wait() == 0
     time.sleep(3.0)
     yield
-    pid = int((tests_dir / 'supervisord.pid').read_text())
+    pid = int((var_dir / 'supervisord.pid').read_text())
     os.kill(pid, signal.SIGTERM)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,9 @@ def wait_for_programs(start_timeout_secs, get_status):
         if all(l.split()[1] == b'RUNNING' for l in status.splitlines()):
             break
     else:
-        raise RuntimeError("test programs failed to start on time")
+        progs = b" ".join(p for (p, s) in (l.split()[:2] for l in status.splitlines())
+                          if s != b'RUNNING').decode()
+        raise RuntimeError(f"test programs failed to start on time: {progs}")
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import signal
 import subprocess
 import time
@@ -12,13 +13,17 @@ from pathlib import Path
 @pytest.fixture(scope='session')
 def services():
     tests_dir = Path('tests')
+    purge_var = False  # toggle to start with an empty state directory
 
     data_dir = tests_dir / 'data'
     if not data_dir.is_dir() and not data_dir.is_symlink():
         data_dir.symlink_to('../root-example', target_is_directory=True)
 
     var_dir = tests_dir / 'var'
-    (var_dir / 'supervisord-logs').mkdir(exist_ok=True)
+    if purge_var and var_dir.is_dir():
+        shutil.rmtree(var_dir)
+    var_dir.mkdir(exist_ok=not purge_var)
+    (var_dir / 'supervisord-logs').mkdir(exist_ok=not purge_var)
 
     popen = subprocess.Popen(['supervisord', '-c', tests_dir / 'supervisor.conf'])
     assert popen.wait() == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ def services():
         data_dir.symlink_to('../root-example', target_is_directory=True)
 
     var_dir = tests_dir / 'var'
+    (var_dir / 'supervisord-logs').mkdir(exist_ok=True)
 
     popen = subprocess.Popen(['supervisord', '-c', tests_dir / 'supervisor.conf'])
     assert popen.wait() == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,18 +9,16 @@ import pytest
 from pathlib import Path
 
 
+def _supervisor_cmd(prog, *args, conf=None):
+    return subprocess.check_output([prog, '-c', conf, *args])
+
+
 def supervisor_start(*args, conf=None):
-    return subprocess.check_call([
-        'supervisord',
-        '-c', conf,
-        *args])
+    return _supervisor_cmd('supervisord', *args, conf=conf)
 
 
 def supervisor_send(*args, conf=None):
-    return subprocess.check_output([
-        'supervisorctl',
-        '-c', conf,
-        *args])
+    return _supervisor_cmd('supervisorctl', *args, conf=conf)
 
 
 def wait_for_programs(start_timeout_secs, get_status):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,13 +29,12 @@ def services():
 
     pid_file = var_dir / 'supervisord.pid'
 
-    popen = subprocess.Popen([
+    subprocess.check_call([
         'supervisord',
         '-c', tests_dir / 'supervisor.conf',
         '-l', var_dir / 'supervisord.log',
         '-q', logs_dir,
         '-j', pid_file])
-    assert popen.wait() == 0
     time.sleep(3.0)
     yield
     pid = int(pid_file.read_text())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def services():
     popen = subprocess.Popen([
         'supervisord',
         '-c', tests_dir / 'supervisor.conf',
+        '-l', var_dir / 'supervisord.log',
         '-q', logs_dir,
         '-j', pid_file])
     assert popen.wait() == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,9 @@ def services():
     if not data_dir.is_dir() and not data_dir.is_symlink():
         data_dir.symlink_to('../root-example', target_is_directory=True)
 
-    popen = subprocess.Popen(['supervisord', '-c', 'tests/supervisor.conf'])
+    popen = subprocess.Popen(['supervisord', '-c', tests_dir / 'supervisor.conf'])
     assert popen.wait() == 0
     time.sleep(3.0)
     yield
-    pid = int(open('tests/supervisord.pid').read())
+    pid = int((tests_dir / 'supervisord.pid').read_text())
     os.kill(pid, signal.SIGTERM)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,11 +23,19 @@ def services():
     if purge_var and var_dir.is_dir():
         shutil.rmtree(var_dir)
     var_dir.mkdir(exist_ok=not purge_var)
-    (var_dir / 'supervisord-logs').mkdir(exist_ok=not purge_var)
 
-    popen = subprocess.Popen(['supervisord', '-c', tests_dir / 'supervisor.conf'])
+    logs_dir = var_dir / 'supervisord-logs'
+    logs_dir.mkdir(exist_ok=not purge_var)
+
+    pid_file = var_dir / 'supervisord.pid'
+
+    popen = subprocess.Popen([
+        'supervisord',
+        '-c', tests_dir / 'supervisor.conf',
+        '-q', logs_dir,
+        '-j', pid_file])
     assert popen.wait() == 0
     time.sleep(3.0)
     yield
-    pid = int((var_dir / 'supervisord.pid').read_text())
+    pid = int(pid_file.read_text())
     os.kill(pid, signal.SIGTERM)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
-import os
 import shutil
-import signal
 import subprocess
 import time
 
@@ -54,11 +52,9 @@ def services():
     logs_dir = var_dir / 'supervisord-logs'
     logs_dir.mkdir(exist_ok=not purge_var)
 
-    pid_file = var_dir / 'supervisord.pid'
-
     supervisor_start('-l', var_dir / 'supervisord.log',
                      '-q', logs_dir,
-                     '-j', pid_file,
+                     '-j', var_dir / 'supervisord.pid',
                      conf=conf_file)
 
     try:
@@ -67,8 +63,6 @@ def services():
         yield
     finally:
         try:
-            pid = int(pid_file.read_text())
+            supervisor_send('shutdown', conf=conf_file)
         except:
             pass
-        else:
-            os.kill(pid, signal.SIGTERM)

--- a/tests/supervisor.conf
+++ b/tests/supervisor.conf
@@ -1,5 +1,18 @@
 [supervisord]
 
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+# Unfortunately there is no easy way to avoid replicating the RPC socket path
+# in a way that works for both Supervisor daemon and control client
+# (nor of having it passed via the command line)
+# -- at least not without using environment variables.
+[unix_http_server]
+file = %(here)s/var/supervisord.sock
+
+[supervisorctl]
+serverurl = unix://%(here)s/var/supervisord.sock
+
 [program:bro]
 command = python %(here)s/../src/bro.py
 directory = %(here)s

--- a/tests/supervisor.conf
+++ b/tests/supervisor.conf
@@ -4,9 +4,12 @@ pidfile = %(here)s/supervisord.pid
 
 [program:bro]
 command = python %(here)s/../src/bro.py
+directory = %(here)s
 
 [program:pub]
 command = sh -c "sleep 0.5 && python %(here)s/../src/pub.py foo %(here)s/data"
+directory = %(here)s
 
 [program:sub]
 command = sh -c "sleep 1.0 && python %(here)s/../src/sub.py"
+directory = %(here)s

--- a/tests/supervisor.conf
+++ b/tests/supervisor.conf
@@ -13,6 +13,11 @@ file = %(here)s/var/supervisord.sock
 [supervisorctl]
 serverurl = unix://%(here)s/var/supervisord.sock
 
+# The delays (sleep) below are a hacky way to serialize the start of programs
+# until the connections that they require can be made,
+# but one that still keeps them independent from each other,
+# so that we can check if each of them fails to start, crashes, etc.
+
 [program:bro]
 command = python %(here)s/../src/bro.py
 directory = %(here)s

--- a/tests/supervisor.conf
+++ b/tests/supervisor.conf
@@ -1,6 +1,7 @@
 [supervisord]
 logfile = %(here)s/var/supervisord.log
 pidfile = %(here)s/var/supervisord.pid
+childlogdir = %(here)s/var/supervisord-logs
 
 [program:bro]
 command = python %(here)s/../src/bro.py

--- a/tests/supervisor.conf
+++ b/tests/supervisor.conf
@@ -13,11 +13,16 @@ file = %(here)s/var/supervisord.sock
 [supervisorctl]
 serverurl = unix://%(here)s/var/supervisord.sock
 
-# The delays (sleep and startsecs) below are
+# The delays ("sleep" and "startsecs") below are
 # a hacky way to serialize the start of programs
 # until the connections that they require can be made,
 # but one that still keeps them independent from each other,
 # so that we can check if each of them fails to start, crashes, etc.
+#
+# Since all programs are started more or less at the same time
+# (even if a "priority" is defined for each program),
+# the "sleep" increases the chances of success of connections to other programs,
+# while "startsecs" does the same when checking that all programs have "RUNNING" status.
 
 [program:bro]
 command = python %(here)s/../src/bro.py

--- a/tests/supervisor.conf
+++ b/tests/supervisor.conf
@@ -1,5 +1,4 @@
 [supervisord]
-logfile = %(here)s/var/supervisord.log
 
 [program:bro]
 command = python %(here)s/../src/bro.py

--- a/tests/supervisor.conf
+++ b/tests/supervisor.conf
@@ -1,7 +1,5 @@
 [supervisord]
 logfile = %(here)s/var/supervisord.log
-pidfile = %(here)s/var/supervisord.pid
-childlogdir = %(here)s/var/supervisord-logs
 
 [program:bro]
 command = python %(here)s/../src/bro.py

--- a/tests/supervisor.conf
+++ b/tests/supervisor.conf
@@ -13,7 +13,8 @@ file = %(here)s/var/supervisord.sock
 [supervisorctl]
 serverurl = unix://%(here)s/var/supervisord.sock
 
-# The delays (sleep) below are a hacky way to serialize the start of programs
+# The delays (sleep and startsecs) below are
+# a hacky way to serialize the start of programs
 # until the connections that they require can be made,
 # but one that still keeps them independent from each other,
 # so that we can check if each of them fails to start, crashes, etc.
@@ -21,11 +22,14 @@ serverurl = unix://%(here)s/var/supervisord.sock
 [program:bro]
 command = python %(here)s/../src/bro.py
 directory = %(here)s
+startsecs = 1
 
 [program:pub]
 command = sh -c "sleep 0.5 && python %(here)s/../src/pub.py foo %(here)s/data"
 directory = %(here)s
+startsecs = 2
 
 [program:sub]
 command = sh -c "sleep 1.0 && python %(here)s/../src/sub.py"
 directory = %(here)s
+startsecs = 3

--- a/tests/supervisor.conf
+++ b/tests/supervisor.conf
@@ -1,6 +1,6 @@
 [supervisord]
-logfile = %(here)s/supervisord.log
-pidfile = %(here)s/supervisord.pid
+logfile = %(here)s/var/supervisord.log
+pidfile = %(here)s/var/supervisord.pid
 
 [program:bro]
 command = python %(here)s/../src/bro.py


### PR DESCRIPTION
This enhances test code with the following features:

- Use `root-example` as data for tests, unless there is a `tests/data` directory (either empty or with data files).
- All variable state from tests is confined to the `tests/var` directory (if you want to reuse your current one, just move it there). It is kept between test executions, but there is a variable `tests.conftest.services():purge_var` which may be toggled to experiment with cleaning up the directory before tests.
- The test Supervisor is always stopped, even on errors.
- The test Supervisor keeps individual programs' logs under `tests/var/supervisor-logs`.
- Last but not least, before running tests there is a polling check (with a timeout) for every program run by Supervisor to reach the `RUNNING` status. Its configuration file uses different delays to make it more likely that programs are fully working while keeping them independent. Finer checks should belong to individual tests.