### PR TITLE
Some fixes in show command and metadata in cache files

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ python src/cli.py info foo/dir2/ds-4d.b2nd
 }
 ```
 
-Also, get we can ask the url of a root:
+Also, we can ask for the url of a root:
 
 ```sh
 python src/cli.py url foo
@@ -138,15 +138,54 @@ python src/cli.py url foo
 http://localhost:8001
 ```
 
-[TODO] Allow to specify a path to a dataset in the url command.
+[TODO] Allow to specify a path to a dataset in the url command (e.g. `url foo/ds-hello.b2frame`).
 
-Finally, tell the subscriber to download the dataset:
+Let's print data from a specified dataset:
+
+```sh
+python src/cli.py show foo/ds-hello.b2frame
+```
+
+```
+b'Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!Hello world!'
+```
+
+TODO: Allow slicing in schunks too (e.g. `foo/ds-hello.b2frame[:10]`)
+
+It allows printing slices instead of the whole dataset too:
+
+```sh
+python src/cli.py show foo/dir2/ds-4d.b2nd[:1]
+```
+
+```
+[[[[ 0. +0.j  1. +1.j  2. +2.j  3. +3.j  4. +4.j]
+   [ 5. +5.j  6. +6.j  7. +7.j  8. +8.j  9. +9.j]
+   [10.+10.j 11.+11.j 12.+12.j 13.+13.j 14.+14.j]
+   [15.+15.j 16.+16.j 17.+17.j 18.+18.j 19.+19.j]]
+
+  [[20.+20.j 21.+21.j 22.+22.j 23.+23.j 24.+24.j]
+   [25.+25.j 26.+26.j 27.+27.j 28.+28.j 29.+29.j]
+   [30.+30.j 31.+31.j 32.+32.j 33.+33.j 34.+34.j]
+   [35.+35.j 36.+36.j 37.+37.j 38.+38.j 39.+39.j]]
+
+  [[40.+40.j 41.+41.j 42.+42.j 43.+43.j 44.+44.j]
+   [45.+45.j 46.+46.j 47.+47.j 48.+48.j 49.+49.j]
+   [50.+50.j 51.+51.j 52.+52.j 53.+53.j 54.+54.j]
+   [55.+55.j 56.+56.j 57.+57.j 58.+58.j 59.+59.j]]]]
+```
+
+TODO: Allow for more complex slices too (e.g. `ds-4d.b2nd[:1,:1]`)
+
+Finally, we can tell the subscriber to download the dataset:
 
 ```sh
 python src/cli.py download foo/dir2/ds-4d.b2nd
 ```
 
-[TODO] Show where the dataset has been downloaded.
+```
+Dataset saved to /.../foo/dir2/ds-4d.b2nd
+```
 
 ## Tests
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -102,8 +102,8 @@ Out[16]:
 For `.b2frame`, or `.b2` files (the latter is mandatory as an additional file extension in generic files), they are read as `SChunk` instances, and `meta` is a dictionary with the following fields:
 
 ```
-In [17]: c = blosc2.SChunk(chunksize=100)
-In [18]: c.fill_special(8 * 100, special_value=blosc2.SpecialValue.UNINIT)
+In [17]: sc = blosc2.SChunk(chunksize=100)
+In [18]: sc.fill_special(8 * 100, special_value=blosc2.SpecialValue.UNINIT)
 Out[18]: 8
 In [19]: dict(chunksize=c.chunksize, typesize=c.typesize, cparams=c.cparams)
 Out[19]:

--- a/src/models.py
+++ b/src/models.py
@@ -17,6 +17,7 @@ import pydantic
 class CParams(pydantic.BaseModel):
     codec: blosc2.Codec
     typesize: int
+    blocksize: int
 
 class SChunk(pydantic.BaseModel):
     blocksize: int

--- a/src/sub.py
+++ b/src/sub.py
@@ -248,7 +248,7 @@ async def get_info(path: str, slice: str = None):
     if slice is None:
         return metadata
 
-    # Reade metadata
+    # Read metadata
     slice_obj = parse_slice(slice)
     array, schunk = utils.open_b2(abspath)
     if array is not None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -36,7 +36,8 @@ def init_b2nd(metadata, urlpath=None):
             urlpath.unlink()
 
     dtype = getattr(np, metadata.dtype)
-    return blosc2.uninit(metadata.shape, dtype, urlpath=urlpath)
+    return blosc2.uninit(metadata.shape, dtype, urlpath=urlpath,
+                         chunks=metadata.chunks, blocks=metadata.blocks)
 
 def init_b2frame(metadata, urlpath=None):
     if urlpath is not None:
@@ -45,13 +46,17 @@ def init_b2frame(metadata, urlpath=None):
             urlpath.unlink()
 
     cparams = metadata.cparams.model_dump()
-    return blosc2.SChunk(
+    sc = blosc2.SChunk(
         metadata.chunksize,
         contiguous=metadata.contiguous,
         cparams=cparams,
         dparams={},
         urlpath=urlpath,
     )
+    sc.fill_special(metadata.nbytes / metadata.typesize,
+                    special_value=blosc2.SpecialValue.UNINIT)
+    return sc
+
 
 def open_b2(abspath):
     suffix = abspath.suffix


### PR DESCRIPTION
This fixes some issues:

* Use the `blocks` and `blocksize` when creating the metadata on `.b2nd` and `.b2frame` cache files respectively.  This is important so that the ingestion of chunks in the subscriber works properly; in particular, the `show` command works now when using datasets with several blocks per chunk.

* `.b2frame` files are filled with `UNINIT` values now.

* The tutorial section in README has been enhanced to include the `show` command.  Also, some more TODOs have been placed or refined.