### PR TITLE
Copy example root into variable test data directory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,14 +38,14 @@ def services():
     purge_var = True  # toggle to keep the state directory on start
     start_timeout_secs = 10
 
-    data_dir = tests_dir / 'data'
-    if not data_dir.is_dir() and not data_dir.is_symlink():
-        data_dir.symlink_to('../root-example', target_is_directory=True)
-
     var_dir = tests_dir / 'caterva2'
     if purge_var and var_dir.is_dir():
         shutil.rmtree(var_dir)
     var_dir.mkdir(exist_ok=not purge_var)
+
+    data_dir = var_dir / 'data'
+    if not data_dir.is_dir() and not data_dir.is_symlink():
+        data_dir.symlink_to('../../root-example', target_is_directory=True)
 
     conf_file = tests_dir / 'supervisor.conf'
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 import time
@@ -39,6 +40,9 @@ def services():
 
     tests_dir = Path(__file__).parent
 
+    src_dir = tests_dir.parent
+    os.environ['CATERVA2_SOURCE'] = str(src_dir)
+
     var_dir = tests_dir / 'caterva2'
     if purge_var and var_dir.is_dir():
         shutil.rmtree(var_dir)
@@ -46,7 +50,7 @@ def services():
 
     data_dir = var_dir / 'data'
     if not data_dir.is_dir() and not data_dir.is_symlink():
-        examples_dir = tests_dir.parent / 'root-example'
+        examples_dir = src_dir / 'root-example'
         data_dir.symlink_to(examples_dir, target_is_directory=True)
 
     conf_file = tests_dir / 'supervisor.conf'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,9 +49,9 @@ def services():
     var_dir.mkdir(exist_ok=not purge_var)
 
     data_dir = var_dir / 'data'
-    if not data_dir.is_dir() and not data_dir.is_symlink():
+    if not data_dir.exists():
         examples_dir = src_dir / 'root-example'
-        data_dir.symlink_to(examples_dir, target_is_directory=True)
+        shutil.copytree(examples_dir, data_dir, symlinks=True)
 
     conf_file = tests_dir / 'supervisor.conf'
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,9 +34,10 @@ def wait_for_programs(start_timeout_secs, get_status):
 
 @pytest.fixture(scope='session')
 def services():
-    tests_dir = Path('tests')
     purge_var = True  # toggle to keep the state directory on start
     start_timeout_secs = 10
+
+    tests_dir = Path(__file__).parent
 
     var_dir = tests_dir / 'caterva2'
     if purge_var and var_dir.is_dir():
@@ -45,7 +46,8 @@ def services():
 
     data_dir = var_dir / 'data'
     if not data_dir.is_dir() and not data_dir.is_symlink():
-        data_dir.symlink_to('../../root-example', target_is_directory=True)
+        examples_dir = tests_dir.parent / 'root-example'
+        data_dir.symlink_to(examples_dir, target_is_directory=True)
 
     conf_file = tests_dir / 'supervisor.conf'
 

--- a/tests/supervisor.conf
+++ b/tests/supervisor.conf
@@ -30,7 +30,7 @@ directory = %(here)s
 startsecs = 1
 
 [program:pub]
-command = sh -c "sleep 0.5 && python %(here)s/../src/pub.py foo %(here)s/data"
+command = sh -c "sleep 0.5 && python %(here)s/../src/pub.py foo %(here)s/caterva2/data"
 directory = %(here)s
 startsecs = 2
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,12 @@
+import os
+import pathlib
 import json
 import subprocess
 
 
 def cli(args):
-    args = ['python', './src/cli.py'] + args + ['--json']
+    cli_path = pathlib.Path(os.environ['CATERVA2_SOURCE']) / 'src' / 'cli.py'
+    args = ['python', str(cli_path)] + args + ['--json']
     ret = subprocess.run(args, capture_output=True, text=True)
     assert ret.returncode == 0
     return json.loads(ret.stdout)


### PR DESCRIPTION
This is intended to ease the adoption of tests that modify data files. Where data files where previously expected at `tests/data` and it was symlinked to `root-example` if missing, here the latter is copied as `tests/caterva2/data`.

Additionally, tests can be invoked no matter where like `pytest -v SOURCE_DIR`, though test variable data dir remains `SOURCE_DIR/tests/caterva2`. This may be a start for supporting creating the `caterva2` directory elsewhere or in the current directory.