### PR TITLE
No partial downloads

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -36,7 +36,7 @@ The client must implement the following commands:
 - `url <root>`: Publisher URL for the REST API that serves the root.
 - `info <dataset>`: Get metadata about a dataset.
 - `show <dataset[slice]>`: Show the data of a dataset. `slice` is optional.
-- `download <dataset[slice]> <output_dir>`: Get the data of a dataset and save it to a local `output_dir` folder. `slice` is optional.
+- `download <dataset> <output_dir>`: Get the data of a dataset and save it to a local `output_dir` folder.
 
 ## Configuration
 
@@ -80,7 +80,7 @@ The client must be implemented in Python 3 (3.9 being the minimal supported vers
 
 - When a `show` command is issued, the client must send a request to the subscriber to retrieve the data of the given dataset.  The subscriber will reply with the data.  The format is inferred from the extension of the output file: `.b2nd` for Blosc2 NDim and `.b2frame` for Blosc2 frames; an n-dim NumPy array and a 1-dim NumPy array will be shown respectively.  All other extensions will be delivered as a raw buffer (e.g. `foo/path/README.md` will be shown as text).
 
-- When a `download` command is issued, the client must send a request to the subscriber to retrieve the data of the dataset.  The subscriber will reply with the data and client should be responsible to store it in its local `<output_dir>` folder. The name of the file will be the same as the dataset path (e.g. `foo/bar.b2nd` will be stored as `<output_dir>/foo/bar.b2nd`). If a slice is provided, it will store the slice of the dataset (e.g. `foo/bar.b2nd[10:20]` will be stored as `<output_dir>/foo/bar[10:20].b2nd`). TODO: see if this format is supported on Windows.
+- When a `download` command is issued, the client must send a request to the subscriber to retrieve the data of the dataset.  The subscriber will reply with the data and client should be responsible to store it in its local `<output_dir>` folder. The name of the file will be the same as the dataset path (e.g. `foo/bar.b2nd` will be stored as `<output_dir>/foo/bar.b2nd`).
 
 The sequence diagram below summarizes how different messages flow between the components of the system.
 
@@ -102,7 +102,7 @@ The publisher will serve the data in its own cache as-is, without decompressing 
 
 Whenever a `show` or `download` command is issued, the subscriber must check if the data in dataset is already in the cache.  If it is, it must check if the dataset has changed in the publisher; for this, it will ask the publisher for the `mtime` in the dataset, and compare it against the `mtime` field in the general JSON database.  If it has changed, it must update the cache.  If it hasn't, it must use the cached data.  If the data of the dataset is not in the cache, it must fetch it and add it to the cache.
 
-In the first implementation, `show` or `download` commands will make the subscriber download the whole data from publisher and store it in its cache folder. In a next version, subscriber will download only the chunks in `[slice]` that are not in cache.
+`show` or `download` commands will make the subscriber download the whole data from publisher and will store it in its cache folder. When a `slice` is provided (only for the `show` command), subscriber will download only the chunks in `[slice]` that are not in cache yet.
 
 ## Metadata
 

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -134,6 +134,10 @@ def download(dataset, host=sub_host_default):
     -------
     str
         The path to the downloaded file.
+
+    Note: If dataset is a regular file, it will be downloaded and decompressed if blosc2
+     is installed. Otherwise, it will be downloaded as is in the internal caches (i.e.
+     compressed, and with the `.b2` extension).
     """
     url = api_utils.get_download_url(dataset, host, {'download': True})
     return api_utils.download_url(url, dataset)

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -119,7 +119,7 @@ def fetch(dataset, host=sub_host_default, slice_=None):
     return data
 
 
-def download(dataset, host=sub_host_default, slice_=None):
+def download(dataset, host=sub_host_default):
     """
     Download a dataset.
 
@@ -129,16 +129,14 @@ def download(dataset, host=sub_host_default, slice_=None):
         The name of the dataset.
     host : str
         The host to query.
-    slice_ : str
-        The slice to download.
 
     Returns
     -------
     str
         The path to the downloaded file.
     """
-    url = api_utils.get_download_url(dataset, host, {'slice_': slice_, 'download': True})
-    return api_utils.download_url(url, dataset, slice_=slice_)
+    url = api_utils.get_download_url(dataset, host, {'download': True})
+    return api_utils.download_url(url, dataset)
 
 
 class Root:
@@ -210,14 +208,9 @@ class File:
     def __repr__(self):
         return f'<File: {self.path}>'
 
-    def get_download_url(self, slice_=None):
+    def get_download_url(self):
         """
-        Get the download URL for a slice of the file.
-
-        Parameters
-        ----------
-        slice_ : int or slice
-            The slice to get.
+        Get the download URL for a file.
 
         Returns
         -------
@@ -230,14 +223,9 @@ class File:
         >>> file = root['ds-1d.b2nd']
         >>> file.get_download_url()
         'http://localhost:8002/files/foo/ds-1d.b2nd'
-        >>> file.get_download_url(1)
-        'http://localhost:8002/files/downloads/foo/ds-1d[1].b2nd'
-        >>> file.get_download_url(slice(0, 10))
-        'http://localhost:8002/files/downloads/foo/ds-1d[:10].b2nd'
         """
-        slice_ = api_utils.slice_to_string(slice_)
         download_path = api_utils.get_download_url(self.path, self.host,
-                                                   {'slice_': slice_, 'download': True})
+                                                   {'download': True})
         return download_path
 
     def __getitem__(self, slice_):
@@ -269,14 +257,9 @@ class File:
         data = api_utils.get_download_url(self.path, self.host, {'slice_': slice_})
         return data
 
-    def download(self, slice_=None):
+    def download(self):
         """
-        Download a slice of the file.
-
-        Parameters
-        ----------
-        slice_ : int or slice
-            The slice to get.
+        Download a file.
 
         Returns
         -------
@@ -289,14 +272,9 @@ class File:
         >>> file = root['ds-1d.b2nd']
         >>> file.download()
         PosixPath('foo/ds-1d.b2nd')
-        >>> file.download(1)
-        PosixPath('foo/ds-1d[1].b2nd')
-        >>> file.download(slice(0, 10))
-        PosixPath('foo/ds-1d[:10].b2nd')
         """
-        url = self.get_download_url(slice_)
-        slice_ = api_utils.slice_to_string(slice_)
-        return api_utils.download_url(url, self.path, slice_=slice_)
+        urlpath = self.get_download_url()
+        return api_utils.download_url(urlpath, str(self.path))
 
 
 class Dataset(File):

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -128,9 +128,7 @@ def cmd_show(args):
 
 @handle_errors
 def cmd_download(args):
-    dataset, params = args.dataset
-    slice_ = params.get('slice_', None)
-    path = cat2.download(dataset, host=args.host, slice_=slice_)
+    path = cat2.download(args.dataset, host=args.host)
 
     print(f'Dataset saved to {path}')
 
@@ -185,7 +183,7 @@ if __name__ == '__main__':
     help = 'Download a dataset and save it in the local system'
     subparser = subparsers.add_parser('download', help=help)
     subparser.add_argument('--json', action='store_true')
-    subparser.add_argument('dataset', type=dataset_with_slice)
+    subparser.add_argument('dataset', type=str)
     subparser.add_argument('output_dir', nargs='?', default='.', type=pathlib.Path)
     subparser.set_defaults(func=cmd_download)
 

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -29,18 +29,6 @@ def my_path(dspath, slice_):
     return dspath
 
 
-def my_urlpath(ds, slice_):
-    path = pathlib.Path(ds.path)
-    suffix = path.suffix
-    slice2 = api_utils.slice_to_string(slice_)
-    if slice2 or suffix not in {'.b2frame', '.b2nd'}:
-        path = 'downloads' / path.with_suffix('')
-        slice3 = f"[{slice2}]" if slice2 else ""
-        path = pathlib.Path(f'{path}{slice3}{suffix}')
-    path = f"http://{cat2.sub_host_default}/files/{path}"
-    return path
-
-
 def test_roots(services):
     roots = cat2.get_roots()
     assert roots[published_root]['name'] == published_root
@@ -67,7 +55,7 @@ def test_file(services):
     assert file.host == cat2.sub_host_default
 
 
-def test_dataset_frame(services, examples_dir):
+def test_index_dataset_frame(services, examples_dir):
     myroot = cat2.Root(published_root, host=cat2.sub_host_default)
     ds = myroot['ds-hello.b2frame']
     assert ds.name == 'ds-hello.b2frame'
@@ -88,7 +76,7 @@ def test_dataset_frame(services, examples_dir):
         assert str(e_info.value) == 'Only step=1 is supported'
 
 
-def test_dataset_1d(services, examples_dir):
+def test_index_dataset_1d(services, examples_dir):
     myroot = cat2.Root(published_root, host=cat2.sub_host_default)
     ds = myroot['ds-1d.b2nd']
     assert ds.name == 'ds-1d.b2nd'
@@ -109,7 +97,7 @@ def test_dataset_1d(services, examples_dir):
 
 
 @pytest.mark.parametrize("name", ['dir1/ds-2d.b2nd', 'dir2/ds-4d.b2nd'])
-def test_dataset_nd(name, services, examples_dir):
+def test_index_dataset_nd(name, services, examples_dir):
     myroot = cat2.Root(published_root, host=cat2.sub_host_default)
     ds = myroot[name]
     example = examples_dir / ds.name
@@ -142,43 +130,10 @@ def test_download_b2nd(name, services, examples_dir):
 
     # Using 2-step download
     urlpath = ds.get_download_url()
-    assert urlpath == my_urlpath(ds, None)
     data = httpx.get(urlpath)
     assert data.status_code == 200
     b = blosc2.ndarray_from_cframe(data.content)
     np.testing.assert_array_equal(a[:], b[:])
-
-
-# TODO: test slices that exceed the array dimensions
-@pytest.mark.parametrize("slice_", [slice(1, 10), slice(4, 8), slice(None), 1])
-@pytest.mark.parametrize("name", ['ds-1d.b2nd', 'dir1/ds-2d.b2nd'])
-def test_download_b2nd_slice(slice_, name, services, examples_dir):
-    myroot = cat2.Root(published_root, host=cat2.sub_host_default)
-    ds = myroot[name]
-    path = ds.download(slice_)
-    dspath = my_path(ds.path, slice_)
-    assert path == dspath
-
-    # Data contents
-    example = examples_dir / name
-    a = blosc2.open(example)
-    b = blosc2.open(path)
-    if isinstance(slice_, int):
-        np.testing.assert_array_equal(a[slice_], b[()])
-    else:
-        np.testing.assert_array_equal(a[slice_], b[:])
-
-    # Using 2-step download
-    urlpath = ds.get_download_url(slice_)
-    path = my_urlpath(ds, slice_)
-    assert urlpath == path
-    data = httpx.get(urlpath)
-    assert data.status_code == 200
-    b = blosc2.ndarray_from_cframe(data.content)
-    if isinstance(slice_, int):
-        np.testing.assert_array_equal(a[slice_], b[()])
-    else:
-        np.testing.assert_array_equal(a[slice_], b[:])
 
 
 def test_download_b2frame(services, examples_dir):
@@ -202,31 +157,6 @@ def test_download_b2frame(services, examples_dir):
     assert a[:] == b[:]
 
 
-# TODO: add an integer slice test when it is supported in blosc2
-@pytest.mark.parametrize("slice_", [slice(1, 10), slice(15, 20), slice(None)])
-def test_download_b2frame_slice(slice_, services, examples_dir):
-    myroot = cat2.Root(published_root, host=cat2.sub_host_default)
-    ds = myroot['ds-hello.b2frame']
-    path = ds.download(slice_)
-    dspath = my_path(ds.path, slice_)
-    assert path == dspath
-
-    # Data contents
-    example = examples_dir / ds.name
-    a = blosc2.open(example)
-    b = blosc2.open(path)
-    assert a[slice_] == b[:]
-
-    # Using 2-step download
-    urlpath = ds.get_download_url(slice_)
-    path = my_urlpath(ds, slice_)
-    assert urlpath == path
-    data = httpx.get(urlpath)
-    assert data.status_code == 200
-    b = blosc2.schunk_from_cframe(data.content)
-    assert a[slice_] == b[:]
-
-
 def test_index_regular_file(services, examples_dir):
     myroot = cat2.Root(published_root, host=cat2.sub_host_default)
     ds = myroot['README.md']
@@ -245,42 +175,20 @@ def test_download_regular_file(services, examples_dir):
     myroot = cat2.Root(published_root, host=cat2.sub_host_default)
     ds = myroot['README.md']
     path = ds.download()
-    assert path == ds.path
+    assert path == pathlib.Path(str(ds.path) + '.b2')
 
     # Data contents
     example = examples_dir / ds.name
     a = open(example).read()
-    b = open(path).read()
-    assert a[:] == b[:]
+    b = blosc2.open(path)
+    # TODO: why do we need .decode() here?
+    assert a[:] == b[:].decode()
 
     # Using 2-step download
     urlpath = ds.get_download_url()
-    assert urlpath == f"http://{cat2.sub_host_default}/files/downloads/{ds.path}"
+    assert urlpath == f"http://{cat2.sub_host_default}/files/{ds.path}.b2"
     data = httpx.get(urlpath)
     assert data.status_code == 200
-    b = data.content.decode()
-    assert a[:] == b[:]
-
-
-@pytest.mark.parametrize("slice_", [slice(1, 10), slice(15, 20), slice(None)])
-def test_download_regular_file_slice(slice_, services, examples_dir):
-    myroot = cat2.Root(published_root, host=cat2.sub_host_default)
-    ds = myroot['README.md']
-    path = ds.download(slice_)
-    dspath = my_path(ds.path, slice_)
-    assert path == dspath
-
-    # Data contents
-    example = examples_dir / ds.name
-    a = open(example).read()
-    b = open(path).read()
-    assert a[slice_] == b[:]
-
-    # Using 2-step download
-    urlpath = ds.get_download_url(slice_)
-    path = my_urlpath(ds, slice_)
-    assert urlpath == path
-    data = httpx.get(urlpath)
-    assert data.status_code == 200
-    b = data.content.decode()
-    assert a[slice_] == b[:]
+    b = blosc2.schunk_from_cframe(data.content)
+    # TODO: why do we need .decode() here?
+    assert a[:] == b[:].decode()

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -175,14 +175,13 @@ def test_download_regular_file(services, examples_dir):
     myroot = cat2.Root(published_root, host=cat2.sub_host_default)
     ds = myroot['README.md']
     path = ds.download()
-    assert path == pathlib.Path(str(ds.path) + '.b2')
+    assert path == ds.path
 
     # Data contents
     example = examples_dir / ds.name
     a = open(example).read()
-    b = blosc2.open(path)
-    # TODO: why do we need .decode() here?
-    assert a[:] == b[:].decode()
+    b = open(path).read()
+    assert a[:] == b[:]
 
     # Using 2-step download
     urlpath = ds.get_download_url()


### PR DESCRIPTION
This PR removes the partial downloads feature.  Partial downloads can have different bad effects:

1) They need a second re-compression to get the relevant slice of the data.  When using lossy codecs, this may lead to further and undesired loss of quality.

2) They require special management on the subscriber (e.g. a new downloads/ directory).

By removing this capability, we avoid these issues.

As a bonus, this PR provides an additional decompression step for the regular files when the `blosc2` package is present on the client side (it is currently optional).