### PR TITLE
New fetch API for better separation of concerns

### DIFF
--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -275,7 +275,7 @@ class File:
         as_schunk : bool
             Whether to use Blosc2 schunk serialization during data transport. If False,
             pickle will be used instead. Default is True, so Blosc2 serialization will
-            be used if Blosc2 is installed.
+            be used if Blosc2 is installed (and data payload is large enough).
 
         Returns
         -------

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -239,8 +239,8 @@ class File:
 
         Parameters
         ----------
-        slice_ : int or slice
-            The slice to get.
+        slice_ : int, slice, tuple of ints and slices, or None
+            The slice to fetch.
 
         Returns
         -------
@@ -258,8 +258,34 @@ class File:
         >>> ds[0:10]
         array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         """
+        data = self.fetch(slice_=slice_)
+        return data
+
+    def fetch(self, slice_=None, as_schunk=True):
+        """
+        Fetch a slice of a dataset.  Can specify transport serialization.
+
+        Similar to `__getitem__()` but this one lets specify whether we want to use Blosc2 schunk
+        serialization or pickle during data transport between the subscriber and the client.
+
+        Parameters
+        ----------
+        slice_ : int, slice, tuple of ints and slices, or None
+            The slice to fetch.
+        as_schunk : bool
+            Whether to use Blosc2 schunk serialization during data transport. If False,
+            pickle will be used instead. Default is True, so Blosc2 serialization will
+            be used if Blosc2 is installed.
+
+        Returns
+        -------
+        numpy.ndarray
+            The slice of the dataset.
+        """
         slice_ = api_utils.slice_to_string(slice_)
-        data = api_utils.fetch_data(self.path, self.host, {'slice_': slice_})
+        as_schunk = api_utils.blosc2_is_here and as_schunk
+        data = api_utils.fetch_data(self.path, self.host,
+                                    {'slice_': slice_, 'as_schunk': as_schunk})
         return data
 
     def download(self):

--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -76,7 +76,7 @@ def fetch_data(path, host, params):
             data = blosc2.decompress2(data)
         except (ValueError, RuntimeError):
             data = blosc2.ndarray_from_cframe(data)
-            data = data[:]
+            data = data[:] if data.ndim == 1 else data[()]
     return data
 
 

--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -63,8 +63,8 @@ def parse_slice(string):
 
 
 def fetch_data(path, host, params):
-    if 'as_schunk' not in params:
-        params['as_schunk'] = blosc2_is_here
+    if 'prefer_schunk' not in params:
+        params['prefer_schunk'] = blosc2_is_here
     response = httpx.get(f'http://{host}/api/fetch/{path}', params=params)
     response.raise_for_status()
     data = response.content

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -346,7 +346,7 @@ async def partial_download(abspath, path, slice_=None):
 
 
 @app.get('/api/fetch/{path:path}')
-async def fetch_data(path: str, slice_: str = None, as_schunk: bool = False):
+async def fetch_data(path: str, slice_: str = None, prefer_schunk: bool = False):
     """
     Fetch a dataset.
 
@@ -356,7 +356,7 @@ async def fetch_data(path: str, slice_: str = None, as_schunk: bool = False):
         The path to the dataset.
     slice_ : str
         The slice to fetch.
-    as_schunk : bool
+    prefer_schunk : bool
         True if the client accepts Blosc2 schunks.
 
     Returns
@@ -400,13 +400,13 @@ async def fetch_data(path: str, slice_: str = None, as_schunk: bool = False):
     if isinstance(array, np.ndarray):
         if array.size == 0:
             # NumPy scalars or 0-dim are not supported by blosc2 yet, so we need to use pickle better
-            as_schunk = False
+            prefer_schunk = False
         elif array.size * array.itemsize < SMALL_DATA:
-            as_schunk = False
+            prefer_schunk = False
     if isinstance(data, bytes) and len(data) < SMALL_DATA:
-        as_schunk = False
+        prefer_schunk = False
 
-    if as_schunk:
+    if prefer_schunk:
         if isinstance(data, np.ndarray):
             data = blosc2.asarray(data)
             data = data.to_cframe()

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -15,6 +15,7 @@ import pickle
 
 # Requirements
 import blosc2
+import numpy as np
 from fastapi import FastAPI, responses
 from fastapi.staticfiles import StaticFiles
 import httpx
@@ -300,7 +301,7 @@ async def get_info(path: str):
     return srv_utils.read_metadata(abspath)
 
 
-async def partial_download(abspath, path, slice_):
+async def partial_download(abspath, path, slice_=None):
     """
     Download the necessary chunks of a dataset.
 
@@ -344,10 +345,10 @@ async def partial_download(abspath, path, slice_):
                 await download_chunk(path, schunk, n)
 
 
-@app.get('/api/download/{path:path}')
-async def download_data(path: str, slice_: str = None, download: bool = False):
+@app.get('/api/fetch/{path:path}')
+async def fetch_data(path: str, slice_: str = None, as_schunk: bool = False):
     """
-    Download or fetch a dataset.
+    Fetch a dataset.
 
     Parameters
     ----------
@@ -355,33 +356,23 @@ async def download_data(path: str, slice_: str = None, download: bool = False):
         The path to the dataset.
     slice_ : str
         The slice to fetch.
-    download : bool
-        True if the intent is to download the dataset from 'files/'.  If False, the data is
-        returned as a StreamingResponse (it is 'fetched').
+    as_schunk : bool
+        True if the client accepts Blosc2 schunks.
 
     Returns
     -------
-    url or StreamingResponse
-        The url of the file in 'files/' if `download` is True, or a StreamingResponse
-        with the data if download is False.
-
+    StreamingResponse
+        The (slice of) dataset as a NumPy array or a Blosc2 schunk.
     """
+
     abspath = lookup_path(path)
     slice_ = api_utils.parse_slice(slice_)
 
     # Download and update the necessary chunks of the schunk in cache
     await partial_download(abspath, path, slice_)
 
-    # Interesting data has been downloaded, let's use it
-    if download:
-        # The complete file is already in the static files/ dir, so return the url.
-        # We don't currently decompress data before downloading, so let's add the extension
-        # in the url, if it is missing.
-        if abspath.suffix == '.b2':
-            path = f'{path}.b2'
-        return f'http://{host}:{port}/files/{path}'
-
     array, schunk = srv_utils.open_b2(abspath)
+    typesize = schunk.typesize
     if slice_:
         if array:
             array = array[slice_] if array.ndim > 0 else array[()]
@@ -393,15 +384,58 @@ async def download_data(path: str, slice_: str = None, download: bool = False):
                 slice_ = slice(slice_, slice_ + 1)
             schunk = schunk[slice_]
 
-    # Pickle and stream response of the NumPy array
+    # Serialization can be done either as:
+    # * a serialized NDArray
+    # * a compressed SChunk (bytes, via blosc2.compress2)
+    # * a pickled NumPy array (specially scalars and 0-dim arrays)
     data = array if array is not None else schunk
     if not slice_:
+        # data is still a SChunk, so we need to get a NumPy array, or a bytes object
         data = data[:]
-    data = pickle.dumps(data, protocol=-1)
-    # TODO: compress data is not working. HTTPX does this automatically?
-    # data = zlib.compress(data)
+    if isinstance(array, np.ndarray) and (array.shape == () or len(array) == 0):
+        # NumPy scalars or 0-dim are not supported by blosc2 yet, so we need to use pickle better
+        as_schunk = False
+    if as_schunk:
+        if isinstance(data, np.ndarray):
+            data = blosc2.asarray(data)
+            data = data.to_cframe()
+        else:
+            # A bytes object can still be compressed
+            data = blosc2.compress2(data, typesize=typesize)
+    else:
+        data = pickle.dumps(data, protocol=-1)
     downloader = srv_utils.iterchunk(data)
     return responses.StreamingResponse(downloader)
+
+
+@app.get('/api/download/{path:path}')
+async def download_data(path: str):
+    """
+    Download a dataset.
+
+    Parameters
+    ----------
+    path : str
+        The path to the dataset.
+
+    Returns
+    -------
+    url
+        The url of the file in 'files/' to be downloaded later on.
+    """
+
+    abspath = lookup_path(path)
+
+    # Download and update the necessary chunks of the schunk in cache
+    await partial_download(abspath, path)
+
+    # The complete file is already in the static files/ dir, so return the url.
+    # We don't currently decompress data before downloading, so let's add the extension
+    # in the url, if it is missing.
+    if abspath.suffix == '.b2':
+        path = f'{path}.b2'
+    return f'http://{host}:{port}/files/{path}'
+
 
 #
 # Command line interface

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -55,7 +55,10 @@ def test_file(services):
     assert file.host == cat2.sub_host_default
 
 
-def test_index_dataset_frame(services, examples_dir):
+@pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
+                                    slice(10, 20, 1)])
+@pytest.mark.parametrize("as_schunk", [True, False])
+def test_index_dataset_frame(slice_, as_schunk, services, examples_dir):
     myroot = cat2.Root(published_root, host=cat2.sub_host_default)
     ds = myroot['ds-hello.b2frame']
     assert ds.name == 'ds-hello.b2frame'
@@ -63,20 +66,28 @@ def test_index_dataset_frame(services, examples_dir):
 
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
-    assert ord(ds[1]) == a[1]  # TODO: why do we need ord() here?
-    assert ds[:1] == a[:1]
-    assert ds[0:10] == a[0:10]
-    assert ds[10:20] == a[10:20]
-    assert ds[:] == a
-    assert ds[10:20:1] == a[10:20:1]
+    if isinstance(slice_, int):
+        assert ord(ds[slice_]) == a[slice_]  # TODO: why do we need ord() here?
+        assert ord(ds.fetch(slice_, as_schunk)) == a[slice_]
+    else:
+        assert ds[slice_] == a[slice_]
+        assert ds.fetch(slice_, as_schunk) == a[slice_]
+
+def test_dataset_step_diff_1(services, examples_dir):
+    myroot = cat2.Root(published_root, host=cat2.sub_host_default)
+    ds = myroot['ds-hello.b2frame']
+    assert ds.name == 'ds-hello.b2frame'
+    assert ds.host == cat2.sub_host_default
     # We don't support step != 1
     with pytest.raises(Exception) as e_info:
-        np.testing.assert_array_equal(ds[::2], a[::2])
-        assert ds[::2] == a[::2]
+        data = ds[::2]
         assert str(e_info.value) == 'Only step=1 is supported'
 
 
-def test_index_dataset_1d(services, examples_dir):
+@pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
+                                    slice(1, 5, 1)])
+@pytest.mark.parametrize("as_schunk", [True, False])
+def test_index_dataset_1d(slice_, as_schunk, services, examples_dir):
     myroot = cat2.Root(published_root, host=cat2.sub_host_default)
     ds = myroot['ds-1d.b2nd']
     assert ds.name == 'ds-1d.b2nd'
@@ -84,35 +95,21 @@ def test_index_dataset_1d(services, examples_dir):
 
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
-    np.testing.assert_array_equal(ds[1], a[1])
-    np.testing.assert_array_equal(ds[:1], a[:1])
-    np.testing.assert_array_equal(ds[0:10], a[0:10])
-    np.testing.assert_array_equal(ds[10:20], a[10:20])
-    np.testing.assert_array_equal(ds[:], a)
-    np.testing.assert_array_equal(ds[10:20:1], a[10:20:1])
-    # We don't support step != 1
-    with pytest.raises(Exception) as e_info:
-        np.testing.assert_array_equal(ds[::2], a[::2])
-        assert str(e_info.value) == 'Only step=1 is supported'
+    np.testing.assert_array_equal(ds[slice_], a[slice_])
+    np.testing.assert_array_equal(ds.fetch(slice_, as_schunk), a[slice_])
 
 
+@pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
+                                    slice(1, 5, 1)])
 @pytest.mark.parametrize("name", ['dir1/ds-2d.b2nd', 'dir2/ds-4d.b2nd'])
-def test_index_dataset_nd(name, services, examples_dir):
+@pytest.mark.parametrize("as_schunk", [True, False])
+def test_index_dataset_nd(slice_, as_schunk, name, services, examples_dir):
     myroot = cat2.Root(published_root, host=cat2.sub_host_default)
     ds = myroot[name]
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
-    np.testing.assert_array_equal(ds[1], a[1])
-    np.testing.assert_array_equal(ds[:1], a[:1])
-    np.testing.assert_array_equal(ds[0:10], a[0:10])
-    # The next is out of bounds, but it is supported (by numpy too)
-    np.testing.assert_array_equal(ds[10:20], a[10:20])
-    np.testing.assert_array_equal(ds[:], a)
-    np.testing.assert_array_equal(ds[1:5:1], a[1:5:1])
-    # We don't support step != 1
-    with pytest.raises(Exception) as e_info:
-        np.testing.assert_array_equal(ds[::2], a[::2])
-        assert str(e_info.value) == 'Only step=1 is supported'
+    np.testing.assert_array_equal(ds[slice_], a[slice_])
+    np.testing.assert_array_equal(ds.fetch(slice_, as_schunk), a[slice_])
 
 
 @pytest.mark.parametrize("name", ['ds-1d.b2nd', 'dir1/ds-2d.b2nd'])
@@ -157,18 +154,22 @@ def test_download_b2frame(services, examples_dir):
     assert a[:] == b[:]
 
 
-def test_index_regular_file(services, examples_dir):
+@pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
+                                    slice(1, 5, 1)])
+@pytest.mark.parametrize("as_schunk", [True, False])
+def test_index_regular_file(slice_, as_schunk, services, examples_dir):
     myroot = cat2.Root(published_root, host=cat2.sub_host_default)
     ds = myroot['README.md']
 
     # Data contents
     example = examples_dir / ds.name
     a = open(example).read().encode()
-    assert ds[:] == a[:]
-    assert ord(ds[1]) == a[1]     # TODO: why do we need ord() here?
-    assert ds[:1] == a[:1]
-    assert ds[0:10] == a[0:10]
-    assert ds[10:20] == a[10:20]
+    if isinstance(slice_, int):
+        assert ord(ds[slice_]) == a[slice_]  # TODO: why do we need ord() here?
+        assert ord(ds.fetch(slice_, as_schunk)) == a[slice_]
+    else:
+        assert ds[slice_] == a[slice_]
+        assert ds.fetch(slice_, as_schunk) == a[slice_]
 
 
 def test_download_regular_file(services, examples_dir):


### PR DESCRIPTION
This adds a new `fetch` API for the HTTP methods.  This is to make intentions more clear, and to simplify the code too.

Also, a new serialization method based on Blosc2 can be used in the communications between the subscriber and the client.  It is active by default if Blosc2 is installed. In comparison with the previous pickle, the new method allows to reduce the bandwidth when a lot of data is to be transferred.  Some tweaking could be used when the length of the data would be too small; then pickle should always win.