### PR TITLE
Basic configuration file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ cat2cli download foo/dir2/ds-4d.b2nd
 Dataset saved to foo/dir2/ds-4d.b2nd
 ```
 
+### Using a configuration file
+
+All the services mentioned above (and clients, to some limited extent) may get their configuration from a `caterva2.toml` file at the current directory.  Please see the `caterva2.sample.toml` file for more information.
+
 ## Tools
 
 Caterva2 includes a simple script to export the full group and dataset hierarchy in an HDF5 file to a new Caterva2 root directory.  You may invoke it like:

--- a/SPECS.md
+++ b/SPECS.md
@@ -44,21 +44,21 @@ There should be a configuration file (by default $CWD/caterva2.toml) where the c
 
 ```
 [broker]
-http = localhost:8000
-statedir = _caterva2/bro
-loglevel = warning
+http = "localhost:8000"
+statedir = "_caterva2/bro"
+loglevel = "warning"
 
 [publisher.1]
-http = localhost:8001
-statedir = _caterva2/pub
-loglevel = warning
-name = foo
-root = root-examples
+http = "localhost:8001"
+statedir = "_caterva2/pub"
+loglevel = "warning"
+name = "foo"
+root = "root-examples"
 
 [subscriber.1]
-http = localhost:8002
-statedir = _caterva2/sub
-loglevel = warning
+http = "localhost:8002"
+statedir = "_caterva2/sub"
+loglevel = "warning"
 ```
 
 

--- a/caterva2.sample.toml
+++ b/caterva2.sample.toml
@@ -1,0 +1,49 @@
+# Example configuration file for Caterva2 components.
+#
+# This may be parsed by different programs, and each program may look up settings in its own section, or in other programs' sections, if present. For instance, there is no setting in the ``subscriber`` section for the broker endpoint; instead, the subscriber program will look ``broker.http`` up. For instance, in a subscriber configuration file::
+#
+#     [broker]
+#     http = ...  # Broker HTTP endpoint, to be used by subscriber.
+#     # No need for more broker settings unless the broker is to use this file.
+#
+#     [subscriber]
+#     ...
+#
+# Some sections may appear multiple times, each with a different ID (see below). However, if you are to use a single program of each category, you should be file with ID-less sections.
+#
+# All sections and settings are optional.
+
+# The configuration of the broker service.
+# Only one of these is allowed for the moment.
+[broker]
+http = "localhost:8000"  # The ``host:port`` endpoint where the service listens for HTTP requests. Other programs may look ``broker.http`` up to find how to connect to a broker.
+statedir = "_caterva2/bro"  # The directory where the service will place state files.
+loglevel = "warning"  # All service messages having this severity or worse will be logged.
+
+# The configuration of the publisher service.
+# Several of these are allowed, each with a different ID (the string after the dot). A publisher invoked with ``--id=something`` will look its configuration up in the ``publisher.something`` section.
+[publisher.1]
+http = "localhost:8001"  # The ``host:port`` endpoint where the service listens for HTTP requests.
+statedir = "_caterva2/pub"  # The directory where the service will place state files.
+loglevel = "warning"  # All service messages having this severity or worse will be logged.
+name = "foo"  # The name given to the root to be registered at the broker. This setting has no default, if it is not defined here, you need to give it to the publisher as an argument.
+root = "root-examples"  # The directory containig the datasets for the registered root.
+
+# Only one of these is allowed. It will be used by a publisher invoked with no ID, or it may be used by other programs to find how to connect to a publisher (``publisher.http``).
+[publisher]
+http = "localhost:8001"
+# ... other settings as above ...
+
+# The configuration of the subscriber service.
+# Several of these are allowed, each with a different ID (the string after the dot). A subscriber invoked with ``--id=something`` will look its configuration up in the ``subscriber.something`` section.
+[subscriber.1]
+http = "localhost:8002"  # The ``host:port`` endpoint where the service listens for HTTP requests.
+statedir = "_caterva2/sub"  # The directory where the service will place state files.
+loglevel = "warning"  # All service messages having this severity or worse will be logged.
+
+# Only one of these is allowed. It will be used by a subscriber invoked with no ID, or it may be used by other programs to find how to connect to a subscriber (``subscriber.http``).
+[subscriber]
+http = "localhost:8001"
+# ... other settings as above ...
+
+# There are no sections for client programs (yet), but they may still access this file to know about other programs' configuration, like the subscriber endpoint.

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -134,8 +134,10 @@ def cmd_download(args):
 
 
 def main():
+    conf = utils.get_conf()
     parser = utils.get_parser()
-    parser.add_argument('--host', default='localhost:8002')
+    parser.add_argument('--host',
+                        default=conf.get('subscriber.http', 'localhost:8002'))
     subparsers = parser.add_subparsers(required=True)
 
     # roots

--- a/caterva2/clients/tbrowser.py
+++ b/caterva2/clients/tbrowser.py
@@ -43,8 +43,10 @@ class TreeApp(App):
 
 
 def main():
+    conf = utils.get_conf()
     parser = utils.get_parser()
-    parser.add_argument('--host', default='localhost:8002')
+    parser.add_argument('--host',
+                        default=conf.get('subscriber.http', 'localhost:8002'))
     parser.add_argument('--root', default='foo')
 
     # Go

--- a/caterva2/services/bro.py
+++ b/caterva2/services/bro.py
@@ -49,11 +49,11 @@ app.include_router(router)
 
 
 def main():
-    conf = srv_utils.get_conf()
-    parser = utils.get_parser(http=conf.get('broker.http', 'localhost:8000'),
-                              loglevel=conf.get('broker.loglevel', 'warning'))
+    conf = srv_utils.get_conf('broker')
+    parser = utils.get_parser(http=conf.get('.http', 'localhost:8000'),
+                              loglevel=conf.get('.loglevel', 'warning'))
     parser.add_argument('--statedir',
-                        default=conf.get('broker.statedir', '_caterva2/bro'),
+                        default=conf.get('.statedir', '_caterva2/bro'),
                         type=pathlib.Path)
     args = utils.run_parser(parser)
 

--- a/caterva2/services/bro.py
+++ b/caterva2/services/bro.py
@@ -49,8 +49,11 @@ app.include_router(router)
 
 
 def main():
-    parser = utils.get_parser(http='localhost:8000')
-    parser.add_argument('--statedir', default='_caterva2/bro', type=pathlib.Path)
+    conf = srv_utils.get_conf()
+    parser = utils.get_parser(http=conf.get('broker.http', 'localhost:8000'))
+    parser.add_argument('--statedir',
+                        default=conf.get('broker.statedir', '_caterva2/bro'),
+                        type=pathlib.Path)
     args = utils.run_parser(parser)
 
     # Init database

--- a/caterva2/services/bro.py
+++ b/caterva2/services/bro.py
@@ -48,7 +48,7 @@ app.include_router(router)
 
 
 def main():
-    conf = srv_utils.get_conf('broker')
+    conf = utils.get_conf('broker')
     parser = utils.get_parser(http=conf.get('.http', 'localhost:8000'),
                               loglevel=conf.get('.loglevel', 'warning'),
                               statedir=conf.get('.statedir', '_caterva2/bro'))

--- a/caterva2/services/bro.py
+++ b/caterva2/services/bro.py
@@ -7,7 +7,6 @@
 # See LICENSE.txt for details about copyright and rights to use.
 ###############################################################################
 
-import pathlib
 import typing
 
 # Requirements
@@ -51,10 +50,8 @@ app.include_router(router)
 def main():
     conf = srv_utils.get_conf('broker')
     parser = utils.get_parser(http=conf.get('.http', 'localhost:8000'),
-                              loglevel=conf.get('.loglevel', 'warning'))
-    parser.add_argument('--statedir',
-                        default=conf.get('.statedir', '_caterva2/bro'),
-                        type=pathlib.Path)
+                              loglevel=conf.get('.loglevel', 'warning'),
+                              statedir=conf.get('.statedir', '_caterva2/bro'))
     args = utils.run_parser(parser)
 
     # Init database

--- a/caterva2/services/bro.py
+++ b/caterva2/services/bro.py
@@ -50,7 +50,8 @@ app.include_router(router)
 
 def main():
     conf = srv_utils.get_conf()
-    parser = utils.get_parser(http=conf.get('broker.http', 'localhost:8000'))
+    parser = utils.get_parser(http=conf.get('broker.http', 'localhost:8000'),
+                              loglevel=conf.get('broker.loglevel', 'warning'))
     parser.add_argument('--statedir',
                         default=conf.get('broker.statedir', '_caterva2/bro'),
                         type=pathlib.Path)

--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -200,10 +200,12 @@ def main():
                               loglevel=conf.get('.loglevel', 'warning'),
                               statedir=conf.get('.statedir', _stdir),
                               id=conf.id)
-    # TODO: really allow getting from config file
-    parser.add_argument('name', default=conf.get('.name'))
-    parser.add_argument('root', default=conf.get('.root', 'data'))
+    parser.add_argument('name', nargs='?', default=conf.get('.name'))
+    parser.add_argument('root', nargs='?', default=conf.get('.root', 'data'))
     args = utils.run_parser(parser)
+    if args.name is None:  # because optional positional arg w/o conf default
+        raise RuntimeError(
+            "root name was not specified in configuration nor in arguments")
 
     # Global configuration
     global broker, name, root

--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -193,13 +193,17 @@ async def get_download(path: str, nchunk: int = -1):
 
 
 def main():
-    conf = srv_utils.get_conf('publisher')  # TODO: support id
+    conf = srv_utils.get_conf('publisher', allow_id=True)
     parser = utils.get_parser(broker=conf.get('broker.http', 'localhost:8000'),
                               http=conf.get('.http', 'localhost:8001'),
                               loglevel=conf.get('.loglevel', 'warning'))
+    _stdir = '_caterva2/pub' + (f'.{conf.id}' if conf.id else '')
     parser.add_argument('--statedir',
-                        default=conf.get('.statedir', '_caterva2/pub'),
+                        default=conf.get('.statedir', _stdir),
                         type=pathlib.Path)
+    parser.add_argument('--id', default=conf.id,
+                        help=("a string to distinguish services "
+                              "of the same category"))
     # TODO: really allow getting from config file
     parser.add_argument('name', default=conf.get('.name'))
     parser.add_argument('root', default=conf.get('.root', 'data'))

--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -196,14 +196,12 @@ def main():
     conf = srv_utils.get_conf('publisher', allow_id=True)
     parser = utils.get_parser(broker=conf.get('broker.http', 'localhost:8000'),
                               http=conf.get('.http', 'localhost:8001'),
-                              loglevel=conf.get('.loglevel', 'warning'))
+                              loglevel=conf.get('.loglevel', 'warning'),
+                              id=conf.id)
     _stdir = '_caterva2/pub' + (f'.{conf.id}' if conf.id else '')
     parser.add_argument('--statedir',
                         default=conf.get('.statedir', _stdir),
                         type=pathlib.Path)
-    parser.add_argument('--id', default=conf.id,
-                        help=("a string to distinguish services "
-                              "of the same category"))
     # TODO: really allow getting from config file
     parser.add_argument('name', default=conf.get('.name'))
     parser.add_argument('root', default=conf.get('.root', 'data'))

--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -194,14 +194,12 @@ async def get_download(path: str, nchunk: int = -1):
 
 def main():
     conf = srv_utils.get_conf('publisher', allow_id=True)
+    _stdir = '_caterva2/pub' + (f'.{conf.id}' if conf.id else '')
     parser = utils.get_parser(broker=conf.get('broker.http', 'localhost:8000'),
                               http=conf.get('.http', 'localhost:8001'),
                               loglevel=conf.get('.loglevel', 'warning'),
+                              statedir=conf.get('.statedir', _stdir),
                               id=conf.id)
-    _stdir = '_caterva2/pub' + (f'.{conf.id}' if conf.id else '')
-    parser.add_argument('--statedir',
-                        default=conf.get('.statedir', _stdir),
-                        type=pathlib.Path)
     # TODO: really allow getting from config file
     parser.add_argument('name', default=conf.get('.name'))
     parser.add_argument('root', default=conf.get('.root', 'data'))

--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -194,7 +194,7 @@ async def get_download(path: str, nchunk: int = -1):
 
 def main():
     conf = srv_utils.get_conf('publisher')  # TODO: support id
-    parser = utils.get_parser(broker='localhost:8000',
+    parser = utils.get_parser(broker=conf.get('broker.http', 'localhost:8000'),
                               http=conf.get('.http', 'localhost:8001'),
                               loglevel=conf.get('.loglevel', 'warning'))
     parser.add_argument('--statedir',

--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -193,10 +193,16 @@ async def get_download(path: str, nchunk: int = -1):
 
 
 def main():
-    parser = utils.get_parser(broker='localhost:8000', http='localhost:8001')
-    parser.add_argument('--statedir', default='_caterva2/pub', type=pathlib.Path)
-    parser.add_argument('name')
-    parser.add_argument('root', default='data')
+    conf = srv_utils.get_conf('publisher')  # TODO: support id
+    parser = utils.get_parser(broker='localhost:8000',
+                              http=conf.get('.http', 'localhost:8001'),
+                              loglevel=conf.get('.loglevel', 'warning'))
+    parser.add_argument('--statedir',
+                        default=conf.get('.statedir', '_caterva2/pub'),
+                        type=pathlib.Path)
+    # TODO: really allow getting from config file
+    parser.add_argument('name', default=conf.get('.name'))
+    parser.add_argument('root', default=conf.get('.root', 'data'))
     args = utils.run_parser(parser)
 
     # Global configuration

--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -193,7 +193,7 @@ async def get_download(path: str, nchunk: int = -1):
 
 
 def main():
-    conf = srv_utils.get_conf('publisher', allow_id=True)
+    conf = utils.get_conf('publisher', allow_id=True)
     _stdir = '_caterva2/pub' + (f'.{conf.id}' if conf.id else '')
     parser = utils.get_parser(broker=conf.get('broker.http', 'localhost:8000'),
                               http=conf.get('.http', 'localhost:8001'),

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -12,6 +12,11 @@ import json
 import pathlib
 import safer
 
+try:
+    import tomllib as toml
+except ImportError:
+    import tomli as toml
+
 # Requirements
 import blosc2
 import fastapi
@@ -247,3 +252,43 @@ class Database:
 
     def __getattr__(self, name):
         return getattr(self.data, name)
+
+#
+# Configuration file
+#
+
+conf_file_name = 'caterva2.toml'
+
+
+class Conf:
+    def __init__(self, conf):
+        self._conf = conf
+
+    def get(self, key, default=None):
+        """Get configuration item with dot-separated `key`.
+
+        The `default` value is returned if any part of the `key` is missing.
+        """
+        keys = key.split('.')
+        conf = self._conf
+        for k in keys:
+            conf = conf.get(k)
+            if conf is None:
+                return default
+        return conf
+
+
+def get_conf():
+    """Get settings from the configuration file, if existing.
+
+    If the configuration file does not exist, return an empyt configuration.
+
+    You may get a value from the returned configuration ``conf`` with
+    ``conf.get('path.to.item'[, default])``.
+    """
+    try:
+        with open(conf_file_name, 'rb') as conf_file:
+            conf = toml.load(conf_file)
+            return Conf(conf)
+    except FileNotFoundError:
+        return Conf({})

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -9,6 +9,7 @@
 
 import asyncio
 import json
+import os
 import pathlib
 import safer
 import sys
@@ -304,7 +305,10 @@ def get_conf(prefix=None, allow_id=False):
         opts = '#'.join(sys.argv)
         match_ = re.search(r'#--id[=#]([^#]+)', opts)
         if match_ is not None:
-            prefix = f'{prefix}.{match_.group(1)}'
+            id_ = match_.group(1)
+            if any(p in id_ for p in [os.curdir, os.pardir, os.sep]):
+                raise ValueError("invalid identifier", id_)
+            prefix = f'{prefix}.{id_}'
     try:
         with open(conf_file_name, 'rb') as conf_file:
             conf = toml.load(conf_file)

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -261,14 +261,19 @@ conf_file_name = 'caterva2.toml'
 
 
 class Conf:
-    def __init__(self, conf):
+    def __init__(self, conf, prefix=None):
         self._conf = conf
+        self.prefix = prefix
 
     def get(self, key, default=None):
         """Get configuration item with dot-separated `key`.
 
         The `default` value is returned if any part of the `key` is missing.
+
+        The prefix (if given) is prepended to a `key` that starts with a dot.
         """
+        if self.prefix is not None and key.startswith('.'):
+            key = self.prefix + key
         keys = key.split('.')
         conf = self._conf
         for k in keys:
@@ -278,17 +283,19 @@ class Conf:
         return conf
 
 
-def get_conf():
+def get_conf(prefix=None):
     """Get settings from the configuration file, if existing.
 
     If the configuration file does not exist, return an empyt configuration.
 
-    You may get a value from the returned configuration ``conf`` with
-    ``conf.get('path.to.item'[, default])``.
+    You may get the value for a key from the returned configuration ``conf``
+    with ``conf.get('path.to.item'[, default])``.  If a `prefix` is given and
+    the key starts with a dot, like ``.path.to.item``, `prefix` is prepended
+    to it.
     """
     try:
         with open(conf_file_name, 'rb') as conf_file:
             conf = toml.load(conf_file)
-            return Conf(conf)
+            return Conf(conf, prefix=prefix)
     except FileNotFoundError:
-        return Conf({})
+        return Conf({}, prefix=prefix)

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -314,6 +314,8 @@ def get_conf(prefix=None, allow_id=False):
             id_ = match_.group(1)
             if any(p in id_ for p in [os.curdir, os.pardir, os.sep]):
                 raise ValueError("invalid identifier", id_)
+        else:
+            id_ = ''
     try:
         with open(conf_file_name, 'rb') as conf_file:
             conf = toml.load(conf_file)

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -410,8 +410,15 @@ async def download_data(path: str, slice_: str = None, download: bool = False):
 #
 
 def main():
-    parser = utils.get_parser(broker='localhost:8000', http='localhost:8002')
-    parser.add_argument('--statedir', default='_caterva2/sub', type=pathlib.Path)
+    conf = srv_utils.get_conf('subscriber', allow_id=True)
+    parser = utils.get_parser(broker=conf.get('broker.http', 'localhost:8000'),
+                              http=conf.get('.http', 'localhost:8002'),
+                              loglevel=conf.get('.loglevel', 'warning'),
+                              id=conf.id)
+    _stdir = '_caterva2/sub' + (f'.{conf.id}' if conf.id else '')
+    parser.add_argument('--statedir',
+                        default=conf.get('.statedir', _stdir),
+                        type=pathlib.Path)
     args = utils.run_parser(parser)
 
     # Global configuration

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -410,7 +410,7 @@ async def download_data(path: str, slice_: str = None, download: bool = False):
 #
 
 def main():
-    conf = srv_utils.get_conf('subscriber', allow_id=True)
+    conf = utils.get_conf('subscriber', allow_id=True)
     _stdir = '_caterva2/sub' + (f'.{conf.id}' if conf.id else '')
     parser = utils.get_parser(broker=conf.get('broker.http', 'localhost:8000'),
                               http=conf.get('.http', 'localhost:8002'),

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -411,14 +411,12 @@ async def download_data(path: str, slice_: str = None, download: bool = False):
 
 def main():
     conf = srv_utils.get_conf('subscriber', allow_id=True)
+    _stdir = '_caterva2/sub' + (f'.{conf.id}' if conf.id else '')
     parser = utils.get_parser(broker=conf.get('broker.http', 'localhost:8000'),
                               http=conf.get('.http', 'localhost:8002'),
                               loglevel=conf.get('.loglevel', 'warning'),
+                              statedir=conf.get('.statedir', _stdir),
                               id=conf.id)
-    _stdir = '_caterva2/sub' + (f'.{conf.id}' if conf.id else '')
-    parser.add_argument('--statedir',
-                        default=conf.get('.statedir', _stdir),
-                        type=pathlib.Path)
     args = utils.run_parser(parser)
 
     # Global configuration

--- a/caterva2/tests/conf.py
+++ b/caterva2/tests/conf.py
@@ -1,0 +1,13 @@
+import pytest
+
+from caterva2 import utils
+
+
+def get_configuration():
+    return utils.get_conf()
+
+
+@pytest.fixture(scope='session')
+def configuration():
+    """Caterva2 configuration, if available"""
+    return get_configuration()

--- a/caterva2/tests/conftest.py
+++ b/caterva2/tests/conftest.py
@@ -1,3 +1,4 @@
+from .conf import configuration  # noqa: F401
 from .files import examples_dir  # noqa: F401
 from .services import services  # noqa: F401
 

--- a/caterva2/tests/services.py
+++ b/caterva2/tests/services.py
@@ -57,21 +57,34 @@ TEST_STATE_DIR = DEFAULT_STATE_DIR + '_tests'
 TEST_PUBLISHED_ROOT = 'foo'
 
 
-def get_local_http(port, path='/'):
+def get_http(host, path='/'):
     def check():
-        url = f'http://localhost:{port:d}{path}'
+        url = f'http://{host}{path}'
         try:
             r = httpx.get(url, timeout=0.5)
             return r.status_code == 200
         except httpx.ConnectError:
             return False
-    check.__name__ = f'get_local_http_{port:d}'  # more descriptive
+    check.__name__ = f'get_http_{host}'  # more descriptive
     return check
 
 
-bro_check = get_local_http(8000, '/api/roots')
-pub_check = get_local_http(8001, '/api/list')
-sub_check = get_local_http(8002, '/api/roots')
+def http_service_check(conf, conf_sect, def_local_port, path):
+    return get_http(conf.get(f'{conf_sect}.http',
+                             f'localhost:{def_local_port:d}'),
+                    path)
+
+
+def bro_check(conf):
+    return http_service_check(conf, 'broker', 8000, '/api/roots')
+
+
+def pub_check(conf):
+    return http_service_check(conf, 'publisher', 8001, '/api/list')
+
+
+def sub_check(conf):
+    return http_service_check(conf, 'subscriber', 8002, '/api/roots')
 
 
 class Services:
@@ -80,10 +93,11 @@ class Services:
 
 class ManagedServices(Services):
     def __init__(self, state_dir, reuse_state=True,
-                 examples_dir=None):
+                 examples_dir=None, configuration=None):
         self.state_dir = Path(state_dir).resolve()
         self.reuse_state = reuse_state
         self.examples_dir = examples_dir
+        self.configuration = configuration
 
         self.data_dir = self.state_dir / 'data'
 
@@ -133,10 +147,10 @@ class ManagedServices(Services):
     def start_all(self):
         self._setup()
 
-        self._start_proc('bro', check=bro_check)
+        self._start_proc('bro', check=bro_check(self.configuration))
         self._start_proc('pub', TEST_PUBLISHED_ROOT, self.data_dir,
-                         check=pub_check)
-        self._start_proc('sub', check=sub_check)
+                         check=pub_check(self.configuration))
+        self._start_proc('sub', check=sub_check(self.configuration))
 
     def stop_all(self):
         for proc in self._procs.values():
@@ -153,7 +167,9 @@ class ManagedServices(Services):
 
 
 class ExternalServices(Services):
-    _checks = [bro_check, pub_check, sub_check]
+    def __init__(self, configuration=None):
+        self.configuration = conf = configuration
+        self._checks = [bro_check(conf), pub_check(conf), sub_check(conf)]
 
     def start_all(self):
         failed = [check.__name__ for check in self._checks if not check()]
@@ -169,11 +185,12 @@ class ExternalServices(Services):
 
 
 @pytest.fixture(scope='session')
-def services(examples_dir):
-    srvs = (ExternalServices()
+def services(examples_dir, configuration):
+    srvs = (ExternalServices(configuration=configuration)
             if os.environ.get('CATERVA2_USE_EXTERNAL', '0') == '1'
             else ManagedServices(TEST_STATE_DIR, reuse_state=False,
-                                 examples_dir=examples_dir))
+                                 examples_dir=examples_dir,
+                                 configuration=configuration))
     try:
         srvs.start_all()
         yield srvs
@@ -187,12 +204,14 @@ def main():
         print(f"Usage: {sys.argv[0]} [STATE_DIRECTORY=\"{DEFAULT_STATE_DIR}\"]")
         return
 
-    from . import files
+    from . import files, conf
 
     state_dir = sys.argv[1] if len(sys.argv) >= 2 else DEFAULT_STATE_DIR
     examples_dir = files.get_examples_dir()
+    configuration = conf.get_configuration()
     srvs = ManagedServices(state_dir, reuse_state=True,
-                           examples_dir=examples_dir)
+                           examples_dir=examples_dir,
+                           configuration=configuration)
     try:
         srvs.start_all()
         srvs.wait_for_all()

--- a/caterva2/tests/services.py
+++ b/caterva2/tests/services.py
@@ -186,6 +186,9 @@ class ExternalServices(Services):
 
 @pytest.fixture(scope='session')
 def services(examples_dir, configuration):
+    # TODO: Consider using a temporary directory to avoid
+    # polluting the current directory with test files
+    # and tests being influenced by the presence of a configuration file.
     srvs = (ExternalServices(configuration=configuration)
             if os.environ.get('CATERVA2_USE_EXTERNAL', '0') == '1'
             else ManagedServices(TEST_STATE_DIR, reuse_state=False,
@@ -208,6 +211,7 @@ def main():
 
     state_dir = sys.argv[1] if len(sys.argv) >= 2 else DEFAULT_STATE_DIR
     examples_dir = files.get_examples_dir()
+    # TODO: Consider allowing path to configuration file, pass here.
     configuration = conf.get_configuration()
     srvs = ManagedServices(state_dir, reuse_state=True,
                            examples_dir=examples_dir,

--- a/caterva2/tests/test_cli.py
+++ b/caterva2/tests/test_cli.py
@@ -13,7 +13,14 @@ import json
 import subprocess
 import sys
 
+import pytest
+
 from .services import TEST_PUBLISHED_ROOT as root_default
+
+
+@pytest.fixture
+def pub_host(configuration):
+    return configuration.get('publisher.http', cat2.pub_host_default)
 
 
 def cli(args, binary=False):
@@ -27,15 +34,15 @@ def cli(args, binary=False):
     return out if binary else json.loads(out)
 
 
-def test_roots(services):
+def test_roots(services, pub_host):
     roots = cli(['roots'])
     assert roots[root_default]['name'] == root_default
-    assert roots[root_default]['http'] == cat2.pub_host_default
+    assert roots[root_default]['http'] == pub_host
 
 
-def test_url(services):
+def test_url(services, pub_host):
     out = cli(['url', root_default])
-    assert out == ['http://localhost:8001']
+    assert out == [f'http://{pub_host}']
 
 
 def test_subscribe(services):

--- a/caterva2/utils.py
+++ b/caterva2/utils.py
@@ -9,6 +9,7 @@
 
 import argparse
 import contextlib
+import pathlib
 import logging
 
 
@@ -48,9 +49,13 @@ def socket_type(string):
     return host, port
 
 
-def get_parser(loglevel='warning', broker=None, http=None, id=None):
+def get_parser(loglevel='warning', statedir=None,
+               broker=None, http=None, id=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('--loglevel', default=loglevel)
+    if statedir:
+        parser.add_argument('--statedir', default=statedir,
+                            type=pathlib.Path)
     if broker:
         parser.add_argument('--broker', default=broker)
     if http:

--- a/caterva2/utils.py
+++ b/caterva2/utils.py
@@ -9,8 +9,16 @@
 
 import argparse
 import contextlib
+import os
 import pathlib
+import sys
+import re
 import logging
+
+try:
+    import tomllib as toml
+except ImportError:
+    import tomli as toml
 
 
 #
@@ -75,3 +83,71 @@ def run_parser(parser):
     logging.basicConfig(level=loglevel)
 
     return args
+
+
+#
+# Configuration file
+#
+
+conf_file_name = 'caterva2.toml'
+
+
+class Conf:
+    def __init__(self, conf, prefix=None, id=None):
+        self._conf = conf
+        self.prefix = prefix
+        self.id = id
+
+        self._pfx = ((f"{prefix}.{id}" if id else prefix) if prefix
+                     else None)
+
+    def get(self, key, default=None):
+        """Get configuration item with dot-separated `key`.
+
+        The `default` value is returned if any part of the `key` is missing.
+
+        The prefix (if given) is prepended to a `key` that starts with a dot.
+        If an ID was given, it is appended to `prefix`, separated by a dot.
+        """
+        if self._pfx is not None and key.startswith('.'):
+            key = self._pfx + key
+        keys = key.split('.')
+        conf = self._conf
+        for k in keys:
+            conf = conf.get(k)
+            if conf is None:
+                return default
+        return conf
+
+
+def get_conf(prefix=None, allow_id=False):
+    """Get settings from the configuration file, if existing.
+
+    If the configuration file does not exist, return an empty configuration.
+
+    You may get the value for a key from the returned configuration ``conf``
+    with ``conf.get('path.to.item'[, default])``.  If a `prefix` is given and
+    the key starts with a dot, like ``.path.to.item``, `prefix` is prepended
+    to it.  If `allow_id` is true and command line arguments has a non-empty
+    value for the ``--id`` option, the value gets appended to `prefix`,
+    separated by a dot.
+
+    For instance, with ``conf = get_conf('foo')`` and ``--id=bar``,
+    ``conf.get('.item')`` is equivalent to ``conf.get('foo.bar.item')``.
+    """
+    id_ = None
+    if allow_id:  # quick'n'dirty argument parsing before full one
+        opts = '#'.join(sys.argv)
+        match_ = re.search(r'#--id[=#]([^#]+)', opts)
+        if match_ is not None:
+            id_ = match_.group(1)
+            if any(p in id_ for p in [os.curdir, os.pardir, os.sep]):
+                raise ValueError("invalid identifier", id_)
+        else:
+            id_ = ''
+    try:
+        with open(conf_file_name, 'rb') as conf_file:
+            conf = toml.load(conf_file)
+            return Conf(conf, prefix=prefix, id=id_)
+    except FileNotFoundError:
+        return Conf({}, prefix=prefix, id=id_)

--- a/caterva2/utils.py
+++ b/caterva2/utils.py
@@ -49,13 +49,9 @@ def socket_type(string):
     return host, port
 
 
-def get_parser(loglevel='warning', statedir=None,
-               broker=None, http=None, id=None):
+def get_parser(loglevel='warning', statedir=None, id=None,
+               http=None, broker=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('--loglevel', default=loglevel)
-    if statedir:
-        parser.add_argument('--statedir', default=statedir,
-                            type=pathlib.Path)
     if broker:
         parser.add_argument('--broker', default=broker)
     if http:
@@ -64,6 +60,10 @@ def get_parser(loglevel='warning', statedir=None,
         parser.add_argument('--id', default=id,
                             help=("a string to distinguish services "
                                   "of the same category"))
+    if statedir:
+        parser.add_argument('--statedir', default=statedir,
+                            type=pathlib.Path)
+    parser.add_argument('--loglevel', default=loglevel)
     return parser
 
 

--- a/caterva2/utils.py
+++ b/caterva2/utils.py
@@ -48,9 +48,9 @@ def socket_type(string):
     return host, port
 
 
-def get_parser(broker=None, http=None):
+def get_parser(loglevel='warning', broker=None, http=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('--loglevel', default='warning')
+    parser.add_argument('--loglevel', default=loglevel)
     if broker:
         parser.add_argument('--broker', default=broker)
     if http:

--- a/caterva2/utils.py
+++ b/caterva2/utils.py
@@ -48,13 +48,17 @@ def socket_type(string):
     return host, port
 
 
-def get_parser(loglevel='warning', broker=None, http=None):
+def get_parser(loglevel='warning', broker=None, http=None, id=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('--loglevel', default=loglevel)
     if broker:
         parser.add_argument('--broker', default=broker)
     if http:
         parser.add_argument('--http', default=http, type=socket_type)
+    if id is not None:  # the empty string is a valid (default) ID
+        parser.add_argument('--id', default=id,
+                            help=("a string to distinguish services "
+                                  "of the same category"))
     return parser
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "httpx",
     "numpy",
     "pytest",
+    "tomli>=2;python_version<\"3.11\"",
 ]
 
 [tool.hatch.version]
@@ -48,7 +49,6 @@ services = [
     "fastapi",
     "fastapi_websocket_pubsub",
     "safer",
-    "tomli>=2;python_version<\"3.11\"",
     "uvicorn",
     "watchfiles",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ services = [
     "fastapi",
     "fastapi_websocket_pubsub",
     "safer",
+    "tomli>=2;python_version<\"3.11\"",
     "uvicorn",
     "watchfiles",
 ]


### PR DESCRIPTION
This adds support for a `$PWD/caterva2.toml` configuration file as mentioned in the specs. Any service or client program may look up its own configuration in there, or the configuration of other programs (e.g. to know their service endpoint). Settings in the configuration file may be overridden by command line options and arguments; this has been achieved by using configuration settings as defaults for `argparse`. Also, some programs allow an `--id` option to support having multiple programs of the same category share the configuration file (as per specs).

Tests have been adapted to handle the presence of a configuration file at the current directory (to some extent), and an example configuration file has been added.

Both the example and the handling of such file by tests may need further work in the future.