### PR TITLE
Add extra feature for tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e '.[services,clients]'
+        pip install -e '.[tests]'
     - name: Test with pytest
       run: |
         pytest

--- a/README-DEVELOPERS.md
+++ b/README-DEVELOPERS.md
@@ -71,14 +71,14 @@ Then, you can run the tests:
 
 ```shell
 cd ..   # to avoid using the source code
-python -c "import caterva2 as cat2; cat2.test(verbose=True)"
+pytest --pyargs caterva2.tests -v  # or "python -m caterva2.tests -v"
 ```
 
 Please note that the services should be not running at this point.  In case you want to check against
 the current services, you can do:
 
 ```shell
-env CATERVA2_USE_EXTERNAL=1 python -c "import caterva2 as cat2; cat2.test(verbose=True)"
+env CATERVA2_USE_EXTERNAL=1 pytest --pyargs caterva2.tests -v
 ```
 
 ## Create docs

--- a/README-DEVELOPERS.md
+++ b/README-DEVELOPERS.md
@@ -71,14 +71,14 @@ Then, you can run the tests:
 
 ```shell
 cd ..   # to avoid using the source code
-pytest --pyargs caterva2.tests -v  # or "python -m caterva2.tests -v"
+python -m caterva2.tests -v
 ```
 
 Please note that the services should be not running at this point.  In case you want to check against
 the current services, you can do:
 
 ```shell
-env CATERVA2_USE_EXTERNAL=1 pytest --pyargs caterva2.tests -v
+env CATERVA2_USE_EXTERNAL=1 python -m caterva2.tests -v
 ```
 
 ## Create docs

--- a/README-DEVELOPERS.md
+++ b/README-DEVELOPERS.md
@@ -7,6 +7,12 @@ There is a `caterva2.tests.services` script that does this.
 
 ## Running the tests
 
+Testing needs Caterva2 to be installed with the `tests` extra:
+
+```sh
+pip install -e .[tests]
+```
+
 ### With managed daemons
 
 This will start the daemons, run the tests, and shut the daemons down:

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ env CATERVA2_USE_EXTERNAL=1 pytest -v
 Also, the tests suite comes with the package, so you can always run it as:
 
 ```sh
-python -c "import caterva2 as cat2; cat2.test(verbose=True)"
+pytest --pyargs caterva2.tests -v  # or "python -m caterva2.tests -v"
 ```
 
 The test publisher will use the files under `root-example`.  After tests finish, state files will be stored under `_caterva2_tests` in case you want to inspect them.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ env CATERVA2_USE_EXTERNAL=1 pytest -v
 Also, the tests suite comes with the package, so you can always run it as:
 
 ```sh
-pytest --pyargs caterva2.tests -v  # or "python -m caterva2.tests -v"
+python -m caterva2.tests -v
 ```
 
 The test publisher will use the files under `root-example`.  After tests finish, state files will be stored under `_caterva2_tests` in case you want to inspect them.

--- a/README.md
+++ b/README.md
@@ -189,7 +189,13 @@ The tool is still pretty limited in its supported input and generated output, pl
 
 ## Tests
 
-The tests can be run as follows:
+Tests need some extra dependencies that you need to install:
+
+```sh
+pip install -e .[tests]
+```
+
+Then tests can be run as follows:
 
 ```sh
 pytest -v

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -22,14 +22,14 @@ Follow the steps in README-DEVELOPERS.md file for locally creating and
 installing the wheel, then test it::
 
   $ cd ..   # to avoid using the source code
-  $ pytest --pyargs caterva2.tests -v
+  $ python -m caterva2.tests -v
   $ cd -
 
 
 You may want to use the existing services for testing the wheel::
 
   $ cd ..   # to avoid using the source code
-  $ env CATERVA2_USE_EXTERNAL=1 pytest --pyargs caterva2.tests -v
+  $ env CATERVA2_USE_EXTERNAL=1 python -m caterva2.tests -v
   $ cd -
 
 
@@ -64,7 +64,7 @@ Tagging and releasing
 Check that the release is available at https://pypi.org/project/caterva2/ and test it with::
 
   $ pip install caterva2
-  $ pytest --pyargs caterva2.tests -v
+  $ python -m caterva2.tests -v
 
 
 Announcing

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -22,14 +22,14 @@ Follow the steps in README-DEVELOPERS.md file for locally creating and
 installing the wheel, then test it::
 
   $ cd ..   # to avoid using the source code
-  $ python -c "import caterva2 as cat2; cat2.test(verbose=True)"
+  $ pytest --pyargs caterva2.tests -v
   $ cd -
 
 
 You may want to use the existing services for testing the wheel::
 
   $ cd ..   # to avoid using the source code
-  $ env CATERVA2_USE_EXTERNAL=1 python -c "import caterva2 as cat2; cat2.test(verbose=True)"
+  $ env CATERVA2_USE_EXTERNAL=1 pytest --pyargs caterva2.tests -v
   $ cd -
 
 
@@ -64,7 +64,7 @@ Tagging and releasing
 Check that the release is available at https://pypi.org/project/caterva2/ and test it with::
 
   $ pip install caterva2
-  $ python -c "import caterva2 as cat2; cat2.test(verbose=True)"
+  $ pytest --pyargs caterva2.tests -v
 
 
 Announcing

--- a/caterva2/__init__.py
+++ b/caterva2/__init__.py
@@ -14,19 +14,3 @@ __version__ = "0.1"
 from .api import bro_host_default, pub_host_default, sub_host_default
 from .api import get_roots, subscribe, get_list, get_info, fetch, download
 from .api import Root, File, Dataset
-
-
-__all__ = [
-    'bro_host_default',
-    'pub_host_default',
-    'sub_host_default',
-    'get_roots',
-    'subscribe',
-    'get_list',
-    'get_info',
-    'fetch',
-    'download',
-    'Root',
-    'File',
-    'Dataset',
-    ]

--- a/caterva2/__init__.py
+++ b/caterva2/__init__.py
@@ -15,27 +15,6 @@ from .api import bro_host_default, pub_host_default, sub_host_default
 from .api import get_roots, subscribe, get_list, get_info, fetch, download
 from .api import Root, File, Dataset
 
-import pytest
-import pathlib
-
-
-def test(verbose=False):
-    """Run the test suite.
-
-    Parameters
-    ----------
-    verbose : bool
-        If True, run the tests in verbose mode.
-
-    Returns
-    -------
-    int
-        Exit code of the test suite.
-    """
-    test_dir = pathlib.Path(__file__).parent / 'tests'
-    verb = "-v" if verbose else ""
-    return pytest.main([verb, test_dir])
-
 
 __all__ = [
     'bro_host_default',
@@ -50,5 +29,4 @@ __all__ = [
     'Root',
     'File',
     'Dataset',
-    'test',
     ]

--- a/caterva2/tests/__init__.py
+++ b/caterva2/tests/__init__.py
@@ -1,1 +1,8 @@
-from caterva2.tests.__main__ import main
+def main(*args, **kwargs):
+    import functools
+    # Avoid `RuntimeWarning` about import order of ``__main__``
+    # resulting in unpredictable behaviour.
+    from caterva2.tests.__main__ import main as tests_main
+
+    functools.update_wrapper(main, tests_main)
+    return tests_main(*args, **kwargs)

--- a/caterva2/tests/__init__.py
+++ b/caterva2/tests/__init__.py
@@ -1,8 +1,6 @@
 def main(*args, **kwargs):
-    import functools
+    """An alias for `caterva2.tests.__main__.main()`."""
     # Avoid `RuntimeWarning` about import order of ``__main__``
     # resulting in unpredictable behaviour.
     from caterva2.tests.__main__ import main as tests_main
-
-    functools.update_wrapper(main, tests_main)
     return tests_main(*args, **kwargs)

--- a/caterva2/tests/__init__.py
+++ b/caterva2/tests/__init__.py
@@ -1,0 +1,1 @@
+from caterva2.tests.__main__ import main

--- a/caterva2/tests/__main__.py
+++ b/caterva2/tests/__main__.py
@@ -17,10 +17,12 @@ def main(verbose=False):
     int
         Exit code of the test suite.
     """
-    test_dir = pathlib.Path(__file__).parent
-    verb = "-v" if verbose else ""
-    return pytest.main([verb, test_dir])
+    args = sys.argv.copy()
+    if verbose:
+        args.append("-v")
+    args.append(pathlib.Path(__file__).parent)
+    return pytest.main(args)
 
 
 if __name__ == '__main__':
-    main(verbose=('--verbose' in sys.argv or '-v' in sys.argv))
+    main()

--- a/caterva2/tests/__main__.py
+++ b/caterva2/tests/__main__.py
@@ -3,20 +3,22 @@ import sys
 import pytest
 
 
-def main(verbose=False):
+def main(verbose=False, args=None):
     """Run the test suite.
 
     Parameters
     ----------
     verbose : bool
         If True, run the tests in verbose mode.
+    args : list[string]
+        Arguments to pass to pytest execution.
 
     Returns
     -------
     int
         Exit code of the test suite.
     """
-    args = sys.argv.copy()
+    args = [] if args is None else args.copy()
     if verbose:
         args.append("-v")
     args.append("--pyargs")
@@ -25,4 +27,4 @@ def main(verbose=False):
 
 
 if __name__ == '__main__':
-    main()
+    main(args=sys.argv)

--- a/caterva2/tests/__main__.py
+++ b/caterva2/tests/__main__.py
@@ -1,4 +1,3 @@
-import pathlib
 import sys
 
 import pytest
@@ -20,7 +19,8 @@ def main(verbose=False):
     args = sys.argv.copy()
     if verbose:
         args.append("-v")
-    args.append(pathlib.Path(__file__).parent)
+    args.append("--pyargs")
+    args.append(__package__)
     return pytest.main(args)
 
 

--- a/caterva2/tests/__main__.py
+++ b/caterva2/tests/__main__.py
@@ -1,0 +1,25 @@
+import pathlib
+
+import pytest
+
+
+def main(verbose=False):
+    """Run the test suite.
+
+    Parameters
+    ----------
+    verbose : bool
+        If True, run the tests in verbose mode.
+
+    Returns
+    -------
+    int
+        Exit code of the test suite.
+    """
+    test_dir = pathlib.Path(__file__).parent
+    verb = "-v" if verbose else ""
+    return pytest.main([verb, test_dir])
+
+
+if __name__ == '__main__':
+    main()

--- a/caterva2/tests/__main__.py
+++ b/caterva2/tests/__main__.py
@@ -1,4 +1,5 @@
 import pathlib
+import sys
 
 import pytest
 
@@ -22,4 +23,4 @@ def main(verbose=False):
 
 
 if __name__ == '__main__':
-    main()
+    main(verbose=('--verbose' in sys.argv or '-v' in sys.argv))

--- a/caterva2/tests/__main__.py
+++ b/caterva2/tests/__main__.py
@@ -21,6 +21,9 @@ def main(verbose=False, args=None):
     args = [] if args is None else args.copy()
     if verbose:
         args.append("-v")
+    # This only happens when using this script mechanism to run tests,
+    # using ``pytest --pyargs caterva2.tests`` is not affected.
+    args.append("-Wignore::pytest.PytestAssertRewriteWarning")
     args.append("--pyargs")
     args.append(__package__)
     return pytest.main(args)

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -37,4 +37,4 @@ running the tests:
 
 .. code-block:: console
 
-    pytest --pyargs caterva2.tests -v  # or "python -m caterva2.tests -v"
+    python -m caterva2.tests -v

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -37,4 +37,4 @@ running the tests:
 
 .. code-block:: console
 
-    python -c "import caterva2 as cat2; cat2.test(verbose=True)"
+    pytest --pyargs caterva2.tests -v  # or "python -m caterva2.tests -v"

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -9,6 +9,12 @@ Pip
 
     python -m pip install caterva2
 
+If you plan to run tests, you may install with the ``tests`` extra:
+
+.. code-block::
+
+    python -m pip install caterva2[tests]
+
 Source code
 +++++++++++
 
@@ -18,6 +24,8 @@ Source code
     cd caterva2
     python -m build
     python -m pip install dist/caterva2-*.whl
+
+If you plan to run tests, you may also add ``[tests]`` right after the wheel name.
 
 That's all. You can proceed with testing section now.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ classifiers = [
 dependencies = [
     "httpx",
     "numpy",
-    "pytest",
     "tomli>=2;python_version<\"3.11\"",
 ]
 
@@ -64,6 +63,11 @@ tools = [
     "h5py",
     "hdf5plugin",
     "msgpack",
+]
+tests = [
+    "caterva2[clients]",
+    "caterva2[services]",
+    "pytest",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
Installing the plain Caterva2 wheel with no extras may result in tests failing, since the dependencies for services and clients are not installed. This means that the only use of the pytest main dependency was to allow the `caterva2.test` function to not break importing `caterva2`, unless one also installed the services and clients extras, something which was not indicated in documentation when referring to tests.

This PR creates an explicit tests extra that depends on the services and clients extras plus pytest (dependency moved here). It is used in CI actions and the documentation has been fixed to mention it, so that tests do work.

~~Invocations of the `caterva2.test` function (now `caterva2.tests.main`) have been replaced with invocations to the more standard `pytest --pyargs caterva2.tests`, although a new script method is supported and mentioned as well (`python -m caterva2.tests`), and invocation from Python code is still possible (with `caterva2.tests.main`).~~

Invocations of the `caterva2.test` function (now `caterva2.tests.main`) have been replaced with script invocation (`python -m caterva2.tests`), which also admits pytest options and avoids an irrelevant `PytestAssertRewriteWarning`.