### PR TITLE
Undo root being part of dataset path in clients

### DIFF
--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -257,7 +257,7 @@ async def get_list(name: str):
     """
     root = get_root(name)
 
-    rootdir = cache
+    rootdir = cache / root.name
     if not rootdir.exists():
         srv_utils.raise_not_found(f'Not subscribed to {name}')
 
@@ -499,7 +499,7 @@ async def html_path_list(
     if not get_root(root).subscribed:
         follow(root)
 
-    rootdir = cache
+    rootdir = cache / root
     paths = [
         relpath.with_suffix('') if relpath.suffix == '.b2' else relpath
         for path, relpath in utils.walk_files(rootdir)
@@ -534,11 +534,11 @@ async def html_path_info(
         }
         return home(request, context)
 
-    filepath = cache / path
+    filepath = cache / root / path
     abspath = lookup_path(filepath)
     meta = srv_utils.read_metadata(abspath)
 
-    context = {"path": pathlib.Path(path), "meta": meta}
+    context = {"path": pathlib.Path(root) / path, "meta": meta}
     response = templates.TemplateResponse(request, "meta.html", context=context)
 
     current_url = furl.furl(hx_current_url)

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -54,8 +54,7 @@ def test_root(services, sub_host):
 def test_list(services, examples_dir, sub_host):
     myroot = cat2.Root(TEST_PUBLISHED_ROOT, host=sub_host)
     example = examples_dir
-    nodes = set(str(TEST_PUBLISHED_ROOT / f.relative_to(str(example)))
-                for f in example.rglob("*") if f.is_file())
+    nodes = set(str(f.relative_to(str(example))) for f in example.rglob("*") if f.is_file())
     assert set(myroot.node_list) == nodes
 
 


### PR DESCRIPTION
This undoes the root being part of datasets in clients (e.g. for listing operations).  One of the issues is when the subscriber is subscribed to more than one root; in this case, listings are merging datasets belonging to different roots.  This PR fixes this.

For what is worth, the actual `urlpath` is still accessible for the user in the metadata view:

<img width="782" alt="image" src="https://github.com/Blosc/Caterva2/assets/314521/4fd4131d-b825-4591-a642-5b3b4eca66e0">
