### PR TITLE
Carry compression params on import/export

### DIFF
--- a/caterva2/tools/cat2_to_hdf5.py
+++ b/caterva2/tools/cat2_to_hdf5.py
@@ -45,8 +45,8 @@ from collections.abc import Callable, Iterator, Mapping
 from .common import BLOSC2_HDF5_FID
 
 
-# Set to an empty mapping to store HDF5 dataset without compression.
-default_h5_compargs = hdf5plugin.Blosc2(cname='zstd', clevel=5, filters=1)
+# Set to empty mapping to store files as uncompressed HDF5 datasets.
+file_h5_compargs = hdf5plugin.Blosc2(cname='zstd', clevel=5, filters=1)
 
 
 def export_dataset(c2_leaf: os.DirEntry, h5_group: h5py.Group,
@@ -135,8 +135,7 @@ def read_file(path: str) -> tuple[Mapping, Mapping]:
         name=pathlib.Path(path).name,
         data=numpy.frombuffer(data, dtype=numpy.uint8),
         chunks=True,
-        **default_h5_cparams,
-        # TODO: compression?
+        **file_h5_compargs,
     )
     # TODO: mark plain file distinguishably
     return kwds, {}

--- a/caterva2/tools/cat2_to_hdf5.py
+++ b/caterva2/tools/cat2_to_hdf5.py
@@ -146,9 +146,9 @@ def h5mkempty_h5chunkit_h5attrs_from_leaf(c2_leaf: os.DirEntry) -> (
         b2_schunk = blosc2.open(c2_leaf.path)
         h5_args |= dict(
             name=pathlib.Path(c2_leaf).stem,
-            # TODO: check for other types/typesizes
-            shape=(b2_schunk.nbytes,),
-            dtype=numpy.uint8,
+            shape=(len(b2_schunk),),
+            dtype=(numpy.uint8 if b2_schunk.typesize == 1
+                   else numpy.dtype('|V%d' % b2_schunk.typesize)),
             chunks=(b2_schunk.chunkshape,),
             **h5compargs_from_b2(b2_schunk),
         )

--- a/caterva2/tools/cat2_to_hdf5.py
+++ b/caterva2/tools/cat2_to_hdf5.py
@@ -106,6 +106,7 @@ def h5compargs_from_b2(b2_array: blosc2.NDArray | blosc2.SChunk) -> Mapping:
 
 def read_array(path: str) -> tuple[Mapping, Mapping]:
     b2_array = blosc2.open(path)
+    # TODO: do not slurp & re-compress
     kwds = dict(
         name=pathlib.Path(path).stem,
         data=b2_array[()],  # ok for arrays & scalars
@@ -118,6 +119,7 @@ def read_array(path: str) -> tuple[Mapping, Mapping]:
 
 def read_frame(path: str) -> tuple[Mapping, Mapping]:
     b2_schunk = blosc2.open(path)
+    # TODO: do not slurp & re-compress
     kwds = dict(
         name=pathlib.Path(path).stem,
         data=numpy.frombuffer(b2_schunk[:], dtype=numpy.uint8),
@@ -131,6 +133,7 @@ def read_frame(path: str) -> tuple[Mapping, Mapping]:
 def read_file(path: str) -> tuple[Mapping, Mapping]:
     with open(path, 'rb') as f:
         data = f.read()
+    # TODO: do not slurp & re-compress
     kwds = dict(
         name=pathlib.Path(path).name,
         data=numpy.frombuffer(data, dtype=numpy.uint8),

--- a/caterva2/tools/cat2_to_hdf5.py
+++ b/caterva2/tools/cat2_to_hdf5.py
@@ -54,7 +54,7 @@ def export_leaf(c2_leaf: os.DirEntry, h5_group: h5py.Group) -> None:
     open HDF5 group `h5_group`.
     """
     try:
-        (h5mkempty, h5_chunks, attrs) = (
+        (h5mkempty, h5_chunks, h5_attrs) = (
             h5mkempty_h5chunkit_h5attrs_from_leaf(c2_leaf))
     except Exception as e:
         logging.error(f"Failed to translate Blosc2 dataset: "
@@ -73,7 +73,7 @@ def export_leaf(c2_leaf: os.DirEntry, h5_group: h5py.Group) -> None:
                       f"{h5_group.name!r}: {c2_leaf.name!r} -> {e!r}")
         return
 
-    for (aname, avalue) in attrs.items():
+    for (aname, avalue) in h5_attrs.items():
         try:
             h5_dataset.attrs[aname] = avalue
             logging.info(f"Exported dataset attribute "

--- a/caterva2/tools/cat2_to_hdf5.py
+++ b/caterva2/tools/cat2_to_hdf5.py
@@ -86,12 +86,21 @@ def h5compargs_from_b2(b2_array: blosc2.NDArray | blosc2.SChunk) -> Mapping:
     cparams = b2_schunk.cparams
     # This is what hdf5plugin does (more or less).
     # Option list as per ``hdf5-blosc2/src/blosc2_filter.c``.
+    #
+    # Note: These HDF5 filter options (``cd_values``)
+    # are just an approximation to the actual cparams/dparams
+    # in the Blosc2 super-chunks stored as HDF5 chunks,
+    # as they are not yet able to encode all Blosc2 features
+    # (like the ordered filter pipeline and meta as of 2024-02).
+    # The cparams/dparams in each schunk are more reliable.
     opts = (
         1,  # filter revision
         cparams['blocksize'],  # block size (in bytes)
         cparams['typesize'],  # type size (in bytes)
         b2_schunk.chunksize,  # chunk size (in bytes)
         cparams['clevel'],  # compression level
+        # Just a coarse hint that filters are used (see note above),
+        # e.g. their order and meta are lost here.
         functools.reduce(operator.or_,  # shuffle method
                          (s.value for s in cparams['filters'])),
         cparams['codec'].value,  # compressor code

--- a/caterva2/tools/cat2_to_hdf5.py
+++ b/caterva2/tools/cat2_to_hdf5.py
@@ -78,6 +78,10 @@ def export_dataset(c2_leaf: os.DirEntry, h5_group: h5py.Group,
 
 
 def h5compargs_from_b2(b2_array: blosc2.NDArray | blosc2.SChunk) -> Mapping:
+    ndim = getattr(b2_array, 'ndim', -1)
+    if ndim == 0:  # scalar, no filters/compression allowed
+        return {}
+
     b2_schunk = getattr(b2_array, 'schunk', b2_array)
     cparams = b2_schunk.cparams
     # This is what hdf5plugin does (more or less).
@@ -92,7 +96,6 @@ def h5compargs_from_b2(b2_array: blosc2.NDArray | blosc2.SChunk) -> Mapping:
                          (s.value for s in cparams['filters'])),
         cparams['codec'].value,  # compressor code
     )
-    ndim = getattr(b2_array, 'ndim', -1)
     if ndim > 1:
         opts += (
             ndim,  # chunk rank (number of dimensions)

--- a/caterva2/tools/cat2_to_hdf5.py
+++ b/caterva2/tools/cat2_to_hdf5.py
@@ -42,13 +42,11 @@ import numpy
 
 from collections.abc import Callable, Iterator, Mapping
 
+from .common import BLOSC2_HDF5_FID
+
 
 # Set to an empty mapping to store HDF5 dataset without compression.
 default_h5_cparams = hdf5plugin.Blosc2(cname='zstd', clevel=5, filters=1)
-
-
-"""The registered identifier for Blosc2 in HDF5 filters."""
-BLOSC2_HDF5_FID = 32026
 
 
 def export_dataset(c2_leaf: os.DirEntry, h5_group: h5py.Group,

--- a/caterva2/tools/cat2_to_hdf5.py
+++ b/caterva2/tools/cat2_to_hdf5.py
@@ -123,6 +123,7 @@ def h5compargs_from_b2(b2_array: blosc2.NDArray | blosc2.SChunk) -> Mapping:
 
 def h5mkempty_h5chunkit_h5attrs_from_leaf(c2_leaf: os.DirEntry) -> (
         Callable[[h5py.Group, ...], h5py.Dataset],
+        Iterator[bytes],
         Mapping):
     # TODO: mark array / frame / file distinguishably
     h5_args = {}

--- a/caterva2/tools/cat2_to_hdf5.py
+++ b/caterva2/tools/cat2_to_hdf5.py
@@ -46,7 +46,7 @@ from .common import BLOSC2_HDF5_FID
 
 
 # Set to an empty mapping to store HDF5 dataset without compression.
-default_h5_cparams = hdf5plugin.Blosc2(cname='zstd', clevel=5, filters=1)
+default_h5_compargs = hdf5plugin.Blosc2(cname='zstd', clevel=5, filters=1)
 
 
 def export_dataset(c2_leaf: os.DirEntry, h5_group: h5py.Group,

--- a/caterva2/tools/common.py
+++ b/caterva2/tools/common.py
@@ -1,0 +1,2 @@
+"""The registered identifier for Blosc2 in HDF5 filters."""
+BLOSC2_HDF5_FID = 32026

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -98,8 +98,9 @@ def b2mkempty_b2chunkit_from_dataset(node: h5py.Dataset) -> (
         # HDF5 filter parameters are less reliable than these.
         b2_array = b2_from_h5_chunk(node, 0)
         b2_schunk = getattr(b2_array, 'schunk', b2_array)
-        if hasattr(b2_array, 'blocks'):
-            b2_args['blocks'] = b2_array.blocks
+        b2_args['blocks'] = getattr(
+            b2_array, 'blocks',
+            (b2_schunk.blocksize // b2_schunk.typesize,))
         b2_args['cparams'] = b2_schunk.cparams
         b2_args['dparams'] = b2_schunk.dparams
         b2chunkit_from_dataset = b2chunkit_from_blosc2

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -188,7 +188,7 @@ def copy_dataset(name: str, node: h5py.Dataset,
                 # so we can handle value subclasses like `numpy.bytes_`
                 # (e.g. for Fortran-style string attributes added by PyTables).
                 pvalue = msgpack.packb(avalue, default=blosc2_ext.encode_tuple)
-                b2_attrs.set_vlmeta(aname, pvalue, typesize=1)  # non-numeric data
+                b2_attrs.set_vlmeta(aname, pvalue, typesize=1)  # non-numeric
                 logging.info(f"Exported dataset attribute {aname!r}: {name!r}")
             except Exception as e:
                 logging.error(f"Failed to export dataset attribute "

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -165,9 +165,16 @@ def b2chunkit_from_chunked(node: h5py.Dataset,
 def copy_dataset(name: str, node: h5py.Dataset,
                  c2_root: pathlib.Path) -> None:
     # TODO: handle array / frame / (compressed) file distinctly
-    b2_path = c2_root / f'{name}.b2nd'
+
     try:
         b2mkempty, b2_chunks = b2mkempty_b2chunkit_from_dataset(node)
+    except Exception as e:
+        logging.error(f"Failed to translate dataset "
+                      f"to Blosc2 ND array: {name!r} -> {e!r}")
+        return
+
+    b2_path = c2_root / f'{name}.b2nd'
+    try:
         b2_array = b2mkempty(urlpath=b2_path, mode='w')
 
         b2_schunk = b2_array.schunk
@@ -188,8 +195,8 @@ def copy_dataset(name: str, node: h5py.Dataset,
                               f"{aname!r}: {name!r} -> {e!r}")
     except Exception as e:
         b2_path.unlink(missing_ok=True)
-        logging.error(f"Failed to export dataset "
-                      f"to Blosc2 ND array: {name!r} -> {e!r}")
+        logging.error(f"Failed to save dataset "
+                      f"as Blosc2 ND array: {name!r} -> {e!r}")
         return
     logging.info(f"Exported dataset: {name!r} => {str(b2_path)!r}")
 

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -100,10 +100,11 @@ def copy_dataset(name: str, node: h5py.Dataset,
         b2_array = b2empty_from_dataset(node, b2_path, b2_args)
         b2_chunks = b2chunks_from_dataset(node, b2_args)
 
+        b2_schunk = b2_array.schunk
         for (nchunk, chunk) in b2_chunks:
-            b2_array.schunk.insert_chunk(nchunk, chunk)
+            b2_schunk.insert_chunk(nchunk, chunk)
 
-        b2_attrs = b2_array.schunk.vlmeta
+        b2_attrs = b2_schunk.vlmeta
         for (aname, avalue) in node.attrs.items():
             try:
                 # This small workaround avoids Blosc2's strict type packing,
@@ -117,8 +118,8 @@ def copy_dataset(name: str, node: h5py.Dataset,
                               f"{aname!r}: {name!r} -> {e!r}")
     except Exception as e:
         b2_path.unlink(missing_ok=True)
-        logging.error(f"Failed to save dataset "
-                      f"as Blosc2 ND array: {name!r} -> {e!r}")
+        logging.error(f"Failed to export dataset "
+                      f"to Blosc2 ND array: {name!r} -> {e!r}")
         return
     logging.info(f"Exported dataset: {name!r} => {str(b2_path)!r}")
 

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -44,7 +44,7 @@ from blosc2 import blosc2_ext
 
 
 """The registered identifier for Blosc2 in HDF5 filters."""
-BLOSC2_HDF5_FID = '32026'
+BLOSC2_HDF5_FID = 32026
 
 
 def create_directory(name: str, node: h5py.Group,
@@ -93,7 +93,7 @@ def b2mkempty_b2chunkit_from_dataset(node: h5py.Dataset) -> (
 
     if node.chunks is None:
         b2chunkit_from_dataset = b2chunkit_from_nonchunked
-    elif BLOSC2_HDF5_FID in node._filters and node.id.get_num_chunks() > 0:
+    elif f'{BLOSC2_HDF5_FID:#d}' in node._filters and node.id.get_num_chunks() > 0:
         # Get Blosc2 arguments from the first schunk.
         # HDF5 filter parameters are less reliable than these.
         b2_array = b2_from_h5_chunk(node, 0)

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -43,6 +43,10 @@ from collections.abc import Iterable, Mapping
 from blosc2 import blosc2_ext
 
 
+"""The registered identifier for Blosc2 in HDF5 filters."""
+BLOSC2_HDF5_FID = '32026'
+
+
 def create_directory(name: str, node: h5py.Group,
                      c2_root: pathlib.Path) -> None:
     if len(node.attrs.keys()) > 0:
@@ -81,7 +85,7 @@ def b2empty_from_dataset(node: h5py.Dataset,
 
 def b2chunks_from_dataset(node: h5py.Dataset,
                           b2_args: Mapping) -> Iterable[(int, bytes)]:
-    if '32026' in node._filters:  # Blosc2's ID
+    if BLOSC2_HDF5_FID in node._filters:
         # Blosc2-compressed dataset, just pass chunks as they are.
         # Support both Blosc2 arrays and frames as HDF5 chunks.
         b2chunk_idx = 0

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -76,6 +76,18 @@ def b2_from_h5_chunk(node: h5py.Dataset,
 def b2mkempty_b2chunkit_from_dataset(node: h5py.Dataset) -> (
         Callable[..., blosc2.NDArray],
         Iterable[bytes]):
+    """Get empty Blosc2 array maker and compressed chunk iterator from `node`.
+
+    The first returned value can be called to create an empty Blosc2 array
+    with prepared construction arguments extracted from the HDF5 dataset
+    `node`.  By default it is created without storage, but that may be changed
+    by passing additional keyword arguments like ``urlpath``.
+
+    The second returned value is an iterator that yields compressed Blosc2
+    chunks compatible with the construction arguments used by the previous
+    callable, for the data in `node`.  They may be stored straight away in
+    order in a Blosc2 super-chunk without further processing.
+    """
     b2_args = dict(
         chunks=node.chunks,  # None is ok (let Blosc2 decide)
     )

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -60,10 +60,13 @@ def create_directory(name: str, node: h5py.Group,
 def copy_dataset(name: str, node: h5py.Dataset,
                  c2_root: pathlib.Path) -> None:
     # TODO: handle array / frame / (compressed) file distinctly
-    # TODO: carry chunk/block shapes
+    # TODO: carry blockshape
     # TODO: carry compression parameters
     try:
-        b2_array = blosc2.asarray(node[()])  # ok for arrays & scalars
+        b2_array = blosc2.asarray(
+            node[()],  # ok for arrays & scalars
+            chunks=node.chunks,  # None is ok (let Blosc2 decide)
+        )
     except ValueError as ve:
         logging.error(f"Failed to convert dataset "
                       f"to Blosc2 ND array: {name!r} -> {ve!r}")

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -121,7 +121,8 @@ def b2chunkit_from_blosc2(node: h5py.Dataset,
 def b2chunkit_from_nonchunked(node: h5py.Dataset,
                               b2_args: Mapping) -> Iterable[bytes]:
     # Contiguous or compact dataset,
-    # slurp into (hopefully small) Blosc2 array and get chunks from it.
+    # slurp into Blosc2 array and get chunks from it.
+    # Hopefully the data is small enough to be loaded into memory.
     src_array = blosc2.asarray(
         node[()],  # ok for arrays & scalars
         **b2_args
@@ -136,6 +137,7 @@ def b2chunkit_from_chunked(node: h5py.Dataset,
     # Non-Blosc2 chunked dataset,
     # load each HDF5 chunk into chunk 0 of compatible Blosc2 array,
     # then get the resulting compressed chunk.
+    # Thus, only one chunk worth of data is kept in memory.
     assert node.chunks == b2_args['chunks']
     src_array = blosc2.empty(
         shape=node.chunks, dtype=node.dtype,  # note that shape is chunkshape

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -42,9 +42,7 @@ from collections.abc import Callable, Iterable, Mapping
 
 from blosc2 import blosc2_ext
 
-
-"""The registered identifier for Blosc2 in HDF5 filters."""
-BLOSC2_HDF5_FID = 32026
+from .common import BLOSC2_HDF5_FID
 
 
 def create_directory(name: str, node: h5py.Group,

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -177,28 +177,28 @@ def copy_dataset(name: str, node: h5py.Dataset,
     b2_path = c2_root / f'{name}.b2nd'
     try:
         b2_array = b2mkempty(urlpath=b2_path, mode='w')
-
         b2_schunk = b2_array.schunk
         for (nchunk, chunk) in enumerate(b2_chunks):
             b2_schunk.update_chunk(nchunk, chunk)
-
-        b2_attrs = b2_schunk.vlmeta
-        for (aname, avalue) in node.attrs.items():
-            try:
-                # This small workaround avoids Blosc2's strict type packing,
-                # so we can handle value subclasses like `numpy.bytes_`
-                # (e.g. for Fortran-style string attributes added by PyTables).
-                pvalue = msgpack.packb(avalue, default=blosc2_ext.encode_tuple)
-                b2_attrs.set_vlmeta(aname, pvalue, typesize=1)  # non-numeric
-                logging.info(f"Exported dataset attribute {aname!r}: {name!r}")
-            except Exception as e:
-                logging.error(f"Failed to export dataset attribute "
-                              f"{aname!r}: {name!r} -> {e!r}")
     except Exception as e:
         b2_path.unlink(missing_ok=True)
         logging.error(f"Failed to save dataset "
                       f"as Blosc2 ND array: {name!r} -> {e!r}")
         return
+
+    b2_attrs = b2_schunk.vlmeta
+    for (aname, avalue) in node.attrs.items():
+        try:
+            # This small workaround avoids Blosc2's strict type packing,
+            # so we can handle value subclasses like `numpy.bytes_`
+            # (e.g. for Fortran-style string attributes added by PyTables).
+            pvalue = msgpack.packb(avalue, default=blosc2_ext.encode_tuple)
+            b2_attrs.set_vlmeta(aname, pvalue, typesize=1)  # non-numeric
+            logging.info(f"Exported dataset attribute {aname!r}: {name!r}")
+        except Exception as e:
+            logging.error(f"Failed to export dataset attribute "
+                          f"{aname!r}: {name!r} -> {e!r}")
+
     logging.info(f"Exported dataset: {name!r} => {str(b2_path)!r}")
 
 

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -38,7 +38,7 @@ import h5py
 import hdf5plugin
 import msgpack
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 
 from blosc2 import blosc2_ext
 
@@ -72,7 +72,7 @@ def b2_from_h5_chunk(node: h5py.Dataset,
 
 def b2mkempty_b2chunkit_from_dataset(node: h5py.Dataset) -> (
         Callable[..., blosc2.NDArray],
-        Iterable[bytes]):
+        Iterator[bytes]):
     """Get empty Blosc2 array maker and compressed chunk iterator from `node`.
 
     The first returned value can be called to create an empty Blosc2 array
@@ -118,7 +118,7 @@ def b2mkempty_b2chunkit_from_dataset(node: h5py.Dataset) -> (
 
 
 def b2chunkit_from_blosc2(node: h5py.Dataset,
-                          b2_args: Mapping) -> Iterable[bytes]:
+                          b2_args: Mapping) -> Iterator[bytes]:
     # Blosc2-compressed dataset, just pass chunks as they are.
     # Support both Blosc2 arrays and frames as HDF5 chunks.
     for h5_chunk_idx in range(node.id.get_num_chunks()):
@@ -130,7 +130,7 @@ def b2chunkit_from_blosc2(node: h5py.Dataset,
 
 
 def b2chunkit_from_nonchunked(node: h5py.Dataset,
-                              b2_args: Mapping) -> Iterable[bytes]:
+                              b2_args: Mapping) -> Iterator[bytes]:
     # Contiguous or compact dataset,
     # slurp into Blosc2 array and get chunks from it.
     # Hopefully the data is small enough to be loaded into memory.
@@ -144,7 +144,7 @@ def b2chunkit_from_nonchunked(node: h5py.Dataset,
 
 
 def b2chunkit_from_chunked(node: h5py.Dataset,
-                           b2_args: Mapping) -> Iterable[bytes]:
+                           b2_args: Mapping) -> Iterator[bytes]:
     # Non-Blosc2 chunked dataset,
     # load each HDF5 chunk into chunk 0 of compatible Blosc2 array,
     # then get the resulting compressed chunk.

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -68,9 +68,8 @@ def create_directory(name: str, node: h5py.Group,
 def b2_from_h5_chunk(node: h5py.Dataset,
                      chunk_index: int) -> (blosc2.NDArray | blosc2.SChunk):
     h5chunk_info = node.id.get_chunk_info(chunk_index)
-    b2 = blosc2.open(node.file.filename, mode='r',
-                     offset=h5chunk_info.byte_offset)
-    return b2
+    return blosc2.open(node.file.filename, mode='r',
+                       offset=h5chunk_info.byte_offset)
 
 
 def b2mkempty_b2chunkit_from_dataset(node: h5py.Dataset) -> (
@@ -108,11 +107,10 @@ def b2mkempty_b2chunkit_from_dataset(node: h5py.Dataset) -> (
         b2chunkit_from_dataset = b2chunkit_from_chunked
 
     def b2_make_empty(**kwds) -> blosc2.NDArray:
-        b2_empty = blosc2.empty(
+        return blosc2.empty(
             shape=node.shape, dtype=node.dtype,
             **(b2_args | kwds)
         )
-        return b2_empty
 
     b2_chunkit = b2chunkit_from_dataset(node, b2_args)
     return b2_make_empty, b2_chunkit

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -93,7 +93,9 @@ def b2mkempty_b2chunkit_from_dataset(node: h5py.Dataset) -> (
 
     if node.chunks is None:
         b2chunkit_from_dataset = b2chunkit_from_nonchunked
-    elif f'{BLOSC2_HDF5_FID:#d}' in node._filters and node.id.get_num_chunks() > 0:
+    elif (list(node._filters) == [f'{BLOSC2_HDF5_FID:#d}']
+          and node.id.get_num_chunks() > 0):
+        # Blosc2 is the sole filter, direct chunk copy is possible.
         # Get Blosc2 arguments from the first schunk.
         # HDF5 filter parameters are less reliable than these.
         b2_array = b2_from_h5_chunk(node, 0)

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -117,7 +117,7 @@ def copy_dataset(name: str, node: h5py.Dataset,
 
         b2_schunk = b2_array.schunk
         for (nchunk, chunk) in b2_chunks:
-            b2_schunk.insert_chunk(nchunk, chunk)
+            b2_schunk.update_chunk(nchunk, chunk)
 
         b2_attrs = b2_schunk.vlmeta
         for (aname, avalue) in node.attrs.items():


### PR DESCRIPTION
This updates `cat2export` and (especially) `cat2import` to respect compression parameters found in Blosc2-compressed datasets (native or in HDF5).

`cat2import` is now able to retrieve parameters from the schunk in a Blosc2-compressed HDF5 dataset, or use default ones for other datasets. In any case, it iterates over chunks one by one, and converts them on-the-fly only if necessary (Blosc2 chunks are copied literally without further processing). That means that at most one chunk is in memory for a converted dataset.

`cat2export` also implements similar techniques for chunk-by-chunk processing (for arrays and frames, although plain files are still slurped and compressed). When creating an HDF5 dataset, default Blosc2 compression parameters are used for plain files, and similar filter cdvalues are computed for Blosc2 datasets, although the parameters in the HDF5 chunk/Blosc2 schunk are more reliable.