### PR TITLE
Use publisher root classes

### DIFF
--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -49,9 +49,10 @@ async def worker(queue):
                     metadata = proot.get_dset_meta(relpath)
                 else:
                     # Compress regular files in publisher's cache
-                    abspath = proot.abspath / relpath
+                    with proot.open_dset_raw(relpath) as f:
+                        data = f.read()
                     b2path = cache / f'{relpath}.b2'
-                    srv_utils.compress(abspath, b2path)
+                    srv_utils.compress(data, b2path)
                     metadata = srv_utils.read_metadata(b2path)
 
                 # Publish

--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -50,7 +50,7 @@ async def worker(queue):
             assert isinstance(abspath, pathlib.Path)
             relpath = abspath.relative_to(root)
             key = str(relpath)
-            if abspath.is_file():
+            if proot.exists_dset(relpath):
                 print('UPDATE', relpath)
                 # Load metadata
                 if abspath.suffix in {'.b2frame', '.b2nd'}:

--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -170,20 +170,14 @@ async def get_download(path: str, nchunk: int = -1):
     relpath = proot.Path(path)
     srv_utils.check_dset_path(proot, relpath)
 
-    abspath = proot.abspath / relpath
-    suffix = relpath.suffix
-    if suffix == '.b2nd':
-        array = blosc2.open(abspath)
-        schunk = array.schunk
-    elif suffix == '.b2frame':
-        schunk = blosc2.open(abspath)
+    if relpath.suffix in {'.b2frame', '.b2nd'}:
+        chunk = proot.get_dset_chunk(relpath, nchunk)
     else:
         b2path = cache / ('%s.b2' % relpath)
         schunk = blosc2.open(b2path)
+        chunk = schunk.get_chunk(nchunk)
 
-    chunk = schunk.get_chunk(nchunk)
     downloader = srv_utils.iterchunk(chunk)
-
     return responses.StreamingResponse(downloader)
 
 

--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -144,7 +144,7 @@ app = FastAPI(lifespan=lifespan)
 
 @app.get("/api/list")
 async def get_list():
-    return list(proot.walk_datasets())
+    return list(proot.walk_dsets())
 
 
 @app.get("/api/info/{path:path}")

--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -200,7 +200,8 @@ def main():
                               statedir=conf.get('.statedir', _stdir),
                               id=conf.id)
     parser.add_argument('name', nargs='?', default=conf.get('.name'))
-    parser.add_argument('root', nargs='?', default=conf.get('.root', 'data'))
+    parser.add_argument('root', nargs='?', default=conf.get('.root', 'data'),
+                        type=pathlib.Path)
     args = utils.run_parser(parser)
     if args.name is None:  # because optional positional arg w/o conf default
         raise RuntimeError(
@@ -210,7 +211,7 @@ def main():
     global broker, name, root
     broker = args.broker
     name = args.name
-    root = pathlib.Path(args.root).resolve()
+    root = args.root.resolve()
 
     # Init cache
     global cache

--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -144,7 +144,7 @@ async def get_info(
     if_none_match: srv_utils.HeaderType = None,
 ):
     relpath = proot.Path(path)
-    abspath = srv_utils.get_abspath(proot.abspath, relpath)
+    srv_utils.check_dset_path(proot, relpath)
 
     # Check etag
     etag = database.etags[str(relpath)]
@@ -168,8 +168,9 @@ async def get_download(path: str, nchunk: int = -1):
         srv_utils.raise_bad_request('Chunk number required')
 
     relpath = proot.Path(path)
-    abspath = srv_utils.get_abspath(proot.abspath, relpath)
+    srv_utils.check_dset_path(proot, relpath)
 
+    abspath = proot.abspath / relpath
     suffix = relpath.suffix
     if suffix == '.b2nd':
         array = blosc2.open(abspath)

--- a/caterva2/services/pubroot.py
+++ b/caterva2/services/pubroot.py
@@ -16,6 +16,9 @@ from collections.abc import AsyncIterator, Collection, Iterator
 import pydantic
 import watchfiles
 
+# Project
+from caterva2.services import srv_utils
+
 
 class PubRoot(ABC):
     Path = pathlib.PurePosixPath
@@ -77,6 +80,10 @@ class DirectoryRoot:
         abspath = self._rel_to_abs(relpath)
         stat = abspath.stat()
         return f'{stat.st_mtime}:{stat.st_size}'
+
+    def get_dset_meta(self, relpath: Path) -> pydantic.BaseModel:
+        abspath = self._rel_to_abs(relpath)
+        return srv_utils.read_metadata(abspath)
 
     async def awatch_dsets(self) -> AsyncIterator[Collection[Path]]:
         async for changes in watchfiles.awatch(proot.abspath):

--- a/caterva2/services/pubroot.py
+++ b/caterva2/services/pubroot.py
@@ -37,3 +37,23 @@ class PubRoot(ABC):
     @abstractmethod
     def get_chunk(self, relpath: Path, nchunk: int) -> bytes:
         ...
+
+
+class DirectoryRoot:
+    Path = PubRoot.Path
+
+    def __init__(self, path: pathlib.Path):
+        abspath = path.resolve(strict=True)
+        # Force an error for non-dirs or non-readable dirs.
+        next(abspath.iterdir())
+
+        self.abspath = abspath
+
+    def walk_datasets(self) -> Iterator[Path]:
+        return (self.Path(p.relative_to(self.abspath))
+                for p in self.abspath.glob('**/*')
+                if not p.is_dir())
+
+    # TODO: pending interface methods
+
+PubRoot.register(DirectoryRoot)

--- a/caterva2/services/pubroot.py
+++ b/caterva2/services/pubroot.py
@@ -19,23 +19,23 @@ class PubRoot(ABC):
     Path = pathlib.PurePosixPath
 
     @abstractmethod
-    def walk_datasets(self) -> Iterator[Path]:
+    def walk_dsets(self) -> Iterator[Path]:
         ...
 
     @abstractmethod
-    def exists_dataset(self, relpath: Path) -> bool:
+    def exists_dset(self, relpath: Path) -> bool:
         ...
 
     @abstractmethod
-    def get_etag(self, relpath: Path) -> str:
+    def get_dset_etag(self, relpath: Path) -> str:
         ...
 
     @abstractmethod
-    def get_metadata(self, relpath: Path) -> pydantic.BaseModel:
+    def get_dset_meta(self, relpath: Path) -> pydantic.BaseModel:
         ...
 
     @abstractmethod
-    def get_chunk(self, relpath: Path, nchunk: int) -> bytes:
+    def get_dset_chunk(self, relpath: Path, nchunk: int) -> bytes:
         ...
 
 
@@ -49,7 +49,7 @@ class DirectoryRoot:
 
         self.abspath = abspath
 
-    def walk_datasets(self) -> Iterator[Path]:
+    def walk_dsets(self) -> Iterator[Path]:
         return (self.Path(p.relative_to(self.abspath))
                 for p in self.abspath.glob('**/*')
                 if not p.is_dir())

--- a/caterva2/services/pubroot.py
+++ b/caterva2/services/pubroot.py
@@ -68,6 +68,11 @@ class DirectoryRoot:
         abspath = self._rel_to_abs(relpath)
         return abspath.is_file()
 
+    def get_dset_etag(self, relpath: Path) -> str:
+        abspath = self._rel_to_abs(relpath)
+        stat = abspath.stat()
+        return f'{stat.st_mtime}:{stat.st_size}'
+
     # TODO: pending interface methods
 
 

--- a/caterva2/services/pubroot.py
+++ b/caterva2/services/pubroot.py
@@ -23,38 +23,52 @@ from caterva2.services import srv_utils
 
 
 class PubRoot(ABC):
+    """Abstract class that represents a publisher root."""
+
+    """The class of dataset (relative) paths."""
     Path = pathlib.PurePosixPath
 
     @abstractmethod
     def walk_dsets(self) -> Iterator[Path]:
+        """Iterate over the relative paths of datasets in this root."""
         ...
 
     @abstractmethod
     def exists_dset(self, relpath: Path) -> bool:
+        """Does the named dataset exist?"""
         ...
 
     @abstractmethod
     def get_dset_etag(self, relpath: Path) -> str:
+        """Get a string that varies if the named dataset is modified."""
         ...
 
     @abstractmethod
     def get_dset_meta(self, relpath: Path) -> pydantic.BaseModel:
+        """Get the metadata of the named dataset."""
         ...
 
     @abstractmethod
     def get_dset_chunk(self, relpath: Path, nchunk: int) -> bytes:
+        """Get compressed chunk with index `nchunk` of the named dataset."""
         ...
 
     @abstractmethod
     def open_dset_raw(self, relpath: Path) -> io.RawIOBase:
+        """Get a byte reader for the raw contents of the named dataset."""
         ...
 
     @abstractmethod
     async def awatch_dsets(self) -> AsyncIterator[Collection[Path]]:
+        """Yield a set of datasets that have been modified."""
         ...
 
 
 class DirectoryRoot:
+    """Represents a publisher root which keeps datasets as files
+    in a directory.
+    """
+
     Path = PubRoot.Path
 
     def __init__(self, path: pathlib.Path):

--- a/caterva2/services/pubroot.py
+++ b/caterva2/services/pubroot.py
@@ -7,6 +7,7 @@
 # See LICENSE.txt for details about copyright and rights to use.
 ###############################################################################
 
+import os
 import pathlib
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
@@ -54,6 +55,20 @@ class DirectoryRoot:
                 for p in self.abspath.glob('**/*')
                 if not p.is_dir())
 
+    def _rel_to_abs(self, relpath: Path) -> pathlib.Path:
+        if relpath.is_absolute():
+            raise ValueError(f"path is not relative: {str(relpath)!r}")
+        # ``.`` is removed on path instantiation, no need to check for it.
+        if os.path.pardir in relpath.parts:
+            raise ValueError(f"{str(os.path.pardir)!r} not allowed "
+                             f"in path: {str(relpath)!r}")
+        return self.abspath / relpath
+
+    def exists_dset(self, relpath: Path) -> bool:
+        abspath = self._rel_to_abs(relpath)
+        return abspath.is_file()
+
     # TODO: pending interface methods
+
 
 PubRoot.register(DirectoryRoot)

--- a/caterva2/services/pubroot.py
+++ b/caterva2/services/pubroot.py
@@ -7,6 +7,7 @@
 # See LICENSE.txt for details about copyright and rights to use.
 ###############################################################################
 
+import io
 import os
 import pathlib
 from abc import ABC, abstractmethod
@@ -42,6 +43,10 @@ class PubRoot(ABC):
 
     @abstractmethod
     def get_dset_chunk(self, relpath: Path, nchunk: int) -> bytes:
+        ...
+
+    @abstractmethod
+    def open_dset_raw(self, relpath: Path) -> io.RawIOBase:
         ...
 
     @abstractmethod
@@ -91,6 +96,10 @@ class DirectoryRoot:
         b2dset = blosc2.open(abspath)
         schunk = getattr(b2dset, 'schunk', b2dset)
         return schunk.get_chunk(nchunk)
+
+    def open_dset_raw(self, relpath: Path) -> io.RawIOBase:
+        abspath = self._rel_to_abs(relpath)
+        return open(abspath, 'rb')
 
     async def awatch_dsets(self) -> AsyncIterator[Collection[Path]]:
         async for changes in watchfiles.awatch(proot.abspath):

--- a/caterva2/services/pubroot.py
+++ b/caterva2/services/pubroot.py
@@ -54,7 +54,7 @@ class PubRoot(ABC):
         ...
 
     @abstractmethod
-    def open_dset_raw(self, relpath: Path) -> io.RawIOBase:
+    def open_dset_raw(self, relpath: Path) -> io.BufferedIOBase:
         """Get a byte reader for the raw contents of the named dataset."""
         ...
 

--- a/caterva2/services/pubroot.py
+++ b/caterva2/services/pubroot.py
@@ -1,0 +1,39 @@
+###############################################################################
+# Caterva2 - On demand access to remote Blosc2 data repositories
+#
+# Copyright (c) 2023 The Blosc Developers <blosc@blosc.org>
+# https://www.blosc.org
+# License: GNU Affero General Public License v3.0
+# See LICENSE.txt for details about copyright and rights to use.
+###############################################################################
+
+import pathlib
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+
+# Requirements
+import pydantic
+
+
+class PubRoot(ABC):
+    Path = pathlib.PurePosixPath
+
+    @abstractmethod
+    def walk_datasets(self) -> Iterator[Path]:
+        ...
+
+    @abstractmethod
+    def exists_dataset(self, relpath: Path) -> bool:
+        ...
+
+    @abstractmethod
+    def get_etag(self, relpath: Path) -> str:
+        ...
+
+    @abstractmethod
+    def get_metadata(self, relpath: Path) -> pydantic.BaseModel:
+        ...
+
+    @abstractmethod
+    def get_chunk(self, relpath: Path, nchunk: int) -> bytes:
+        ...

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -135,9 +135,9 @@ def check_dset_path(proot, path):
         exists = proot.exists_dset(path)
     except ValueError:
         raise_bad_request(f'Invalid path {path}')
-
-    if not exists:
-        raise_not_found()
+    else:
+        if not exists:
+            raise_not_found()
 
 #
 # Blosc2 related helpers

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -129,6 +129,16 @@ def get_abspath(root, path):
 
     return abspath
 
+
+def check_dset_path(proot, path):
+    try:
+        exists = proot.exists_dset(path)
+    except ValueError:
+        raise_bad_request(f'Invalid path {path}')
+
+    if not exists:
+        raise_not_found()
+
 #
 # Blosc2 related helpers
 #


### PR DESCRIPTION
This PR places an abstraction layer in front of root/dataset access at the publisher, so that operations on the root or its datasets follow an interface defined in the `caterva2.servicess.pubroot.PubRoot` abstract base class.

The implementation for the usual directory-based root now constitutes the `DirectoryRoot` class in the same module.

This should hopefully help adding other root implementations like HDF5 or Zip files.