### PR TITLE
Convert dataset attributes to Blosc2 vlmeta in HDF5 publisher root

### DIFF
--- a/caterva2/hdf5.py
+++ b/caterva2/hdf5.py
@@ -79,7 +79,8 @@ def b2args_from_h5dset(h5_dset: h5py.Dataset) -> Mapping[str, object]:
 def _b2maker_from_h5dset(b2make: Callable[..., blosc2.NDArray]):
     def _b2make_from_h5dset(h5_dset: h5py.Dataset, b2_args=None,
                             **kwds) -> blosc2.NDArray:
-        b2_args = b2_args or b2args_from_h5dset(h5_dset)
+        b2_args = (b2_args if b2_args is not None
+                   else b2args_from_h5dset(h5_dset))
         b2_array = b2make(shape=h5_dset.shape, dtype=h5_dset.dtype,
                           **(b2_args | kwds))
         return b2_array

--- a/caterva2/hdf5.py
+++ b/caterva2/hdf5.py
@@ -106,6 +106,18 @@ def b2attrs_from_h5dset(
 
 
 def _b2maker_from_h5dset(b2make: Callable[..., blosc2.NDArray]):
+    """Get a factory to create a Blosc2 array compatible with an HDF dataset.
+
+    The result may be called with the dataset and optional Blosc2 creation
+    arguments and msgpack-encoded attributes (which will be added to the
+    array's variable-length metadata), plus other keyword arguments.  The
+    dataset-compatible Blosc2 array will be created using the `b2make`
+    callable.
+
+    If the aforementioned optional parameters are not given, they will be
+    extracted anew from the HDF5 dataset (which may be an expensive operation
+    depending on the case).
+    """
     def _b2make_from_h5dset(h5_dset: h5py.Dataset,
                             b2_args=None, b2_attrs=None,
                             **kwds) -> blosc2.NDArray:

--- a/caterva2/hdf5.py
+++ b/caterva2/hdf5.py
@@ -80,10 +80,14 @@ def b2args_from_h5dset(h5_dset: h5py.Dataset) -> Mapping[str, object]:
 
 def b2attrs_from_h5dset(
         h5_dset: h5py.Dataset,
-        on_success: Callable[[h5py.Dataset, str], None]=None,
-        on_error: Callable[[h5py.Dataset, str, Exception], None]=None) -> (
+        attr_ok: Callable[[h5py.Dataset, str], None]=None,
+        attr_err: Callable[[h5py.Dataset, str, Exception], None]=None) -> (
             Mapping[str, object]):
-    """Get msgpack-encoded attributes from the given HDF5 dataset."""
+    """Get msgpack-encoded attributes from the given HDF5 dataset.
+
+    If given, call `attr_ok` or `attr_err` on attribute translation success or
+    error, respectively.
+    """
     b2_attrs = {}
     for (aname, avalue) in h5_dset.attrs.items():
         try:
@@ -92,12 +96,12 @@ def b2attrs_from_h5dset(
             # (e.g. for Fortran-style string attributes added by PyTables).
             pvalue = msgpack.packb(avalue, default=blosc2_ext.encode_tuple)
         except Exception as e:
-            if on_error:
-                on_error(h5_dset, aname, e)
+            if attr_err:
+                attr_err(h5_dset, aname, e)
         else:
             b2_attrs[aname] = pvalue
-            if on_success:
-                on_success(h5_dset, aname)
+            if attr_ok:
+                attr_ok(h5_dset, aname)
     return b2_attrs
 
 

--- a/caterva2/hdf5.py
+++ b/caterva2/hdf5.py
@@ -80,8 +80,8 @@ def b2args_from_h5dset(h5_dset: h5py.Dataset) -> Mapping[str, object]:
 
 def b2attrs_from_h5dset(
         h5_dset: h5py.Dataset,
-        attr_ok: Callable[[h5py.Dataset, str], None]=None,
-        attr_err: Callable[[h5py.Dataset, str, Exception], None]=None) -> (
+        attr_ok: Callable[[h5py.Dataset, str], None] = None,
+        attr_err: Callable[[h5py.Dataset, str, Exception], None] = None) -> (
             Mapping[str, object]):
     """Get msgpack-encoded attributes from the given HDF5 dataset.
 

--- a/caterva2/hdf5.py
+++ b/caterva2/hdf5.py
@@ -1,3 +1,12 @@
+###############################################################################
+# Caterva2 - On demand access to remote Blosc2 data repositories
+#
+# Copyright (c) 2023 The Blosc Developers <blosc@blosc.org>
+# https://www.blosc.org
+# License: GNU Affero General Public License v3.0
+# See LICENSE.txt for details about copyright and rights to use.
+###############################################################################
+
 from collections.abc import Callable, Iterator, Mapping
 
 # Requirements

--- a/caterva2/hdf5.py
+++ b/caterva2/hdf5.py
@@ -102,12 +102,19 @@ def b2attrs_from_h5dset(
 
 
 def _b2maker_from_h5dset(b2make: Callable[..., blosc2.NDArray]):
-    def _b2make_from_h5dset(h5_dset: h5py.Dataset, b2_args=None,
+    def _b2make_from_h5dset(h5_dset: h5py.Dataset,
+                            b2_args=None, b2_attrs=None,
                             **kwds) -> blosc2.NDArray:
         b2_args = (b2_args if b2_args is not None
                    else b2args_from_h5dset(h5_dset))
+        b2_attrs = (b2_attrs if b2_attrs is not None
+                    else b2attrs_from_h5dset(h5_dset))
+
         b2_array = b2make(shape=h5_dset.shape, dtype=h5_dset.dtype,
                           **(b2_args | kwds))
+        b2_vlmeta = b2_array.schunk.vlmeta
+        for (aname, avalue) in b2_attrs.items():
+            b2_vlmeta.set_vlmeta(aname, avalue, typesize=1)  # non-numeric
         return b2_array
     return _b2make_from_h5dset
 

--- a/caterva2/services/hdf5root.py
+++ b/caterva2/services/hdf5root.py
@@ -1,3 +1,12 @@
+###############################################################################
+# Caterva2 - On demand access to remote Blosc2 data repositories
+#
+# Copyright (c) 2023 The Blosc Developers <blosc@blosc.org>
+# https://www.blosc.org
+# License: GNU Affero General Public License v3.0
+# See LICENSE.txt for details about copyright and rights to use.
+###############################################################################
+
 import functools
 import io
 import logging

--- a/caterva2/services/hdf5root.py
+++ b/caterva2/services/hdf5root.py
@@ -118,7 +118,8 @@ class HDF5Root:
     def get_dset_meta(self, relpath: Path) -> pydantic.BaseModel:
         dset = self._path_to_dset(relpath)
         b2_args = self._b2args_from_h5dset(dset)
-        b2_array = hdf5.b2uninit_from_h5dset(dset, b2_args)
+        b2_attrs = hdf5.b2attrs_from_h5dset(dset)  # TODO: cache?
+        b2_array = hdf5.b2uninit_from_h5dset(dset, b2_args, b2_attrs)
         return srv_utils.read_metadata(b2_array)
 
     def get_dset_chunk(self, relpath: Path, nchunk: int) -> bytes:

--- a/caterva2/tools/hdf5_to_cat2.py
+++ b/caterva2/tools/hdf5_to_cat2.py
@@ -75,9 +75,9 @@ def b2mkempty_b2chunkit_from_dataset(node: h5py.Dataset) -> (
     b2_args = hdf5.b2args_from_h5dset(node)
     b2_attrs = hdf5.b2attrs_from_h5dset(
         node,
-        on_success=lambda n, a: logging.info(
+        attr_ok=lambda n, a: logging.info(
             f"Translated dataset attribute {a!r}: {n.name!r}"),
-        on_error=lambda n, a, e: logging.error(
+        attr_err=lambda n, a, e: logging.error(
             f"Failed to translate dataset attribute "
             f"{a!r}: {n.name!r} -> {e!r}"),
     )


### PR DESCRIPTION
This extends the work in #28 with on-the-fly translation of attributes in HDF5 datasets. The msgpacked attributes are cached for efficiency. Preliminary tests have been performed with basic attributes like strings, but the machinery may need extra work for other attribute types (as is the case with `cat2import`, which now shares code with this).