### PR TITLE
Add support for displaying md files

### DIFF
--- a/caterva2/services/templates/info.html
+++ b/caterva2/services/templates/info.html
@@ -9,13 +9,23 @@
         </button>
     </li>
     {% if display %}
-    <li class="nav-item" role="presentation">
-        <button type="button" class="nav-link" id="display-tab"
-                data-bs-toggle="tab" data-bs-target="#display-tab-pane"
-                role="tab" aria-controls="metadata-tab-pane" aria-selected="false">
-            Display
-        </button>
-    </li>
+        {% if display.name in ['markdown'] %}
+            <li class="nav-item" role="presentation">
+                <button type="button" class="nav-link" id="markdown-tab"
+                        data-bs-toggle="tab" data-bs-target="#markdown-tab-pane"
+                        role="tab" aria-controls="metadata-tab-pane" aria-selected="false">
+                    Display
+                </button>
+            </li>
+        {% else %}
+            <li class="nav-item" role="presentation">
+                <button type="button" class="nav-link" id="display-tab"
+                        data-bs-toggle="tab" data-bs-target="#display-tab-pane"
+                        role="tab" aria-controls="metadata-tab-pane" aria-selected="false">
+                    Display
+                </button>
+            </li>
+        {% endif %}
     {% endif %}
 </ul>
 
@@ -25,9 +35,16 @@
         {% include 'info_metadata.html' %}
     </div>
     {% if display %}
-    <div class="tab-pane fade" id="display-tab-pane" tabindex="0"
-         role="tabpanel" aria-labelledby="tab-display"
-         hx-get="/plugins/{{ display.name }}/display/{{ path }}" hx-trigger="load">
-    </div>
+        {% if display.name in ['markdown'] %}
+            <div class="tab-pane fade" id="markdown-tab-pane" tabindex="0"
+                 role="tabpanel" aria-labelledby="tab-display"
+                 hx-get="/{{ display.name }}/{{ path }}" hx-trigger="load">
+            </div>
+        {% else %}
+            <div class="tab-pane fade" id="display-tab-pane" tabindex="0"
+                 role="tabpanel" aria-labelledby="tab-display"
+                 hx-get="/plugins/{{ display.name }}/display/{{ path }}" hx-trigger="load">
+            </div>
+        {% endif %}
     {% endif %}
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ services = [
     "fastapi_websocket_pubsub",
     "furl",
     "jinja2",
+    "markdown",
     "pydantic>=2",
     "python-multipart",
     "safer",

--- a/root-example/README.md
+++ b/root-example/README.md
@@ -1,3 +1,6 @@
+# Header example
 This is a simple example,
+
 with several lines,
+
 for showing purposes.


### PR DESCRIPTION
This adds support for displaying a markdown file. It doesn't depend on the `contenttype`, rather if the original file is a "md", an html is always created with the contents of the markdown files when the user clicks on `Display`.