### PR TITLE
Fix init_b2 arguments for array/schunk creation

### DIFF
--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -188,7 +188,10 @@ def init_b2nd(metadata, urlpath=None):
 
     dtype = np.dtype(metadata.dtype)
     arr = blosc2.uninit(metadata.shape, dtype, urlpath=urlpath,
-                        chunks=metadata.chunks, blocks=metadata.blocks)
+                        chunks=metadata.chunks, blocks=metadata.blocks,
+                        # Force contiguous storage until
+                        # non-contiguous datasets are handled properly.
+                        contiguous=True)
     for k, v in metadata.schunk.vlmeta.items():
         arr.schunk.vlmeta[k] = v
     return arr
@@ -203,7 +206,9 @@ def init_b2frame(metadata, urlpath=None):
     cparams = metadata.cparams.model_dump()
     sc = blosc2.SChunk(
         metadata.chunksize,
-        contiguous=metadata.contiguous,
+        # Force contiguous storage until
+        # non-contiguous datasets are handled properly.
+        contiguous=True,
         cparams=cparams,
         dparams={},
         urlpath=urlpath,

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -193,7 +193,7 @@ def init_b2nd(metadata, urlpath=None):
                         # Force contiguous storage until
                         # non-contiguous datasets are handled properly.
                         contiguous=True,
-                        cparams=cparams)
+                        cparams=cparams, dparams={})
     for k, v in metadata.schunk.vlmeta.items():
         arr.schunk.vlmeta[k] = v
     return arr

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -180,46 +180,41 @@ def compress(data, dst=None):
     return schunk
 
 
-def init_b2nd(metadata, urlpath=None):
+def _init_b2(make_b2, metadata, urlpath=None):
     if urlpath is not None:
         urlpath.parent.mkdir(exist_ok=True, parents=True)
         if urlpath.exists():
             urlpath.unlink()
 
-    cparams = metadata.schunk.cparams.model_dump()
-    dtype = np.dtype(metadata.dtype)
+    schunk_meta = getattr(metadata, 'schunk', metadata)
     # Let default behaviour decide whether to use contiguous storage or not,
     # depending on where the dataset is going to be stored.
     # The original value is irrelevant.
-    arr = blosc2.uninit(metadata.shape, dtype, urlpath=urlpath,
-                        chunks=metadata.chunks, blocks=metadata.blocks,
-                        cparams=cparams, dparams={})
-    for k, v in metadata.schunk.vlmeta.items():
-        arr.schunk.vlmeta[k] = v
-    return arr
+    b2_args = dict(urlpath=urlpath, dparams={},
+                   cparams=schunk_meta.cparams.model_dump())
+    b2 = make_b2(**b2_args)
+
+    b2_vlmeta = getattr(b2, 'schunk', b2).vlmeta
+    for k, v in schunk_meta.vlmeta.items():
+        b2_vlmeta[k] = v
+    return b2
+
+
+def init_b2nd(metadata, urlpath=None):
+    def make_b2nd(**kwargs):
+        return blosc2.uninit(metadata.shape, np.dtype(metadata.dtype),
+                             chunks=metadata.chunks, blocks=metadata.blocks,
+                             **kwargs)
+    return _init_b2(make_b2nd, metadata, urlpath)
 
 
 def init_b2frame(metadata, urlpath=None):
-    if urlpath is not None:
-        urlpath.parent.mkdir(exist_ok=True, parents=True)
-        if urlpath.exists():
-            urlpath.unlink()
-
-    cparams = metadata.cparams.model_dump()
-    # Let default behaviour decide whether to use contiguous storage or not,
-    # depending on where the dataset is going to be stored.
-    # The original value is irrelevant.
-    sc = blosc2.SChunk(
-        metadata.chunksize,
-        cparams=cparams,
-        dparams={},
-        urlpath=urlpath,
-    )
-    sc.fill_special(metadata.nbytes / sc.typesize,
-                    special_value=blosc2.SpecialValue.UNINIT)
-    for k, v in metadata.vlmeta.items():
-        sc.vlmeta[k] = v
-    return sc
+    def make_b2frame(**kwargs):
+        sc = blosc2.SChunk(metadata.chunksize, **kwargs)
+        sc.fill_special(metadata.nbytes / sc.typesize,
+                        special_value=blosc2.SpecialValue.UNINIT)
+        return sc
+    return _init_b2(make_b2frame, metadata, urlpath)
 
 
 def init_b2(abspath, metadata):

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -186,12 +186,14 @@ def init_b2nd(metadata, urlpath=None):
         if urlpath.exists():
             urlpath.unlink()
 
+    cparams = metadata.schunk.cparams.model_dump()
     dtype = np.dtype(metadata.dtype)
     arr = blosc2.uninit(metadata.shape, dtype, urlpath=urlpath,
                         chunks=metadata.chunks, blocks=metadata.blocks,
                         # Force contiguous storage until
                         # non-contiguous datasets are handled properly.
-                        contiguous=True)
+                        contiguous=True,
+                        cparams=cparams)
     for k, v in metadata.schunk.vlmeta.items():
         arr.schunk.vlmeta[k] = v
     return arr

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -188,11 +188,11 @@ def init_b2nd(metadata, urlpath=None):
 
     cparams = metadata.schunk.cparams.model_dump()
     dtype = np.dtype(metadata.dtype)
+    # Let default behaviour decide whether to use contiguous storage or not,
+    # depending on where the dataset is going to be stored.
+    # The original value is irrelevant.
     arr = blosc2.uninit(metadata.shape, dtype, urlpath=urlpath,
                         chunks=metadata.chunks, blocks=metadata.blocks,
-                        # Force contiguous storage until
-                        # non-contiguous datasets are handled properly.
-                        contiguous=True,
                         cparams=cparams, dparams={})
     for k, v in metadata.schunk.vlmeta.items():
         arr.schunk.vlmeta[k] = v
@@ -206,11 +206,11 @@ def init_b2frame(metadata, urlpath=None):
             urlpath.unlink()
 
     cparams = metadata.cparams.model_dump()
+    # Let default behaviour decide whether to use contiguous storage or not,
+    # depending on where the dataset is going to be stored.
+    # The original value is irrelevant.
     sc = blosc2.SChunk(
         metadata.chunksize,
-        # Force contiguous storage until
-        # non-contiguous datasets are handled properly.
-        contiguous=True,
         cparams=cparams,
         dparams={},
         urlpath=urlpath,


### PR DESCRIPTION
This fixes two issues with the creation of Blosc2 datasets (e.g. in cache files at the subscriber):

1. The `contiguous` attribute being copied from the original when creating a frame dataset file. Just let the default storage be used when creating the dataset locally, as non-contiguous datasets are not properly supported by the publisher (which opens the inner `chunks.b2nd` and crashes), and its value may not be meaningful for virtual datasets (e.g. those dynamically generated by the HDF5 root publisher). (The default was correctly used in array dataset creation.)
2. The `cparams` attribute not being propagated from the original when creating an array dataset file. Although individual chunks kept their parameters, the super-chunk always got default ones.

Some minor refactoring has been performed to avoid further inconsistencies between frame and array creation.