### PR TITLE
Experimental user authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,18 @@ Dataset saved to foo/dir2/ds-4d.b2nd
 
 All the services mentioned above (and clients, to some limited extent) may get their configuration from a `caterva2.toml` file at the current directory (or an alternative file given with the `--conf` option).  Caterva2 source code includes a fully documented `caterva2.sample.toml` file (see also [caterva2.toml](caterva2.toml) in Caterva2 tutorials).
 
+### Experimental user authentication
+
+The Caterva2 subscriber includes some initial and incomplete support for authenticating users.  To enable it, run the subscriber with the environment variable `CATERVA2_AUTH_SECRET` set to some non-empty, secure string that will be used for various user management operations.  After that, accessing the subscriber's Web client will only be possible after logging in with an email address and a password.  New accounts may be registered, but their addresses are not verified.  Password recovery does not work either.
+
+Also note that, although the subscriber side of the client API does support user authentication (using cookies), it is not yet supported by the client API implementation shipped with Caterva2.  You may still play with it using an HTTP client like cURL:
+
+```sh
+curl -v --json '{"email":"foo@example.com","password":"bar"}' http://localhost:8002/auth/register
+curl -v -d'username=foo@example.com' -d'password=bar' http://localhost:8002/auth/jwt/login  # -> "Set-Cookie: fastapi...t3IM; ..."
+curl -v -b'fastapi...t3IM' http://localhost:8002/api/roots
+```
+
 ## Tools
 
 Although Caterva2 allows publishing an HDF5 file directly as a root (with datasets converted to Blosc2 arrays on-the-fly), it also includes a simple script that can import its full hierarchy to a new Caterva2 root directory.  You may use it like:

--- a/README.md
+++ b/README.md
@@ -229,9 +229,10 @@ The Caterva2 subscriber includes some initial and incomplete support for authent
 Also note that, although the subscriber side of the client API does support user authentication (using cookies), it is not yet supported by the client API implementation shipped with Caterva2.  You may still play with it using an HTTP client like cURL:
 
 ```sh
-curl -v --json '{"email":"foo@example.com","password":"bar"}' http://localhost:8002/auth/register
-curl -v -d'username=foo@example.com' -d'password=bar' http://localhost:8002/auth/jwt/login  # -> "Set-Cookie: c2subauth=...t3IM; ..."
-curl -v -b'c2subauth=...t3IM' http://localhost:8002/api/roots
+C2SUB=http://localhost:8002
+curl -v --json '{"email":"foo@example.com","password":"bar"}' $C2SUB/auth/register
+curl -v -d'username=foo@example.com' -d'password=bar' $C2SUB/auth/jwt/login #→Set-Cookie: c2subauth=…xxx;…
+curl -v -b'c2subauth=…xxx' $C2SUB/api/roots
 ```
 
 ## Tools

--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ Also note that, although the subscriber side of the client API does support user
 
 ```sh
 curl -v --json '{"email":"foo@example.com","password":"bar"}' http://localhost:8002/auth/register
-curl -v -d'username=foo@example.com' -d'password=bar' http://localhost:8002/auth/jwt/login  # -> "Set-Cookie: fastapi...t3IM; ..."
-curl -v -b'fastapi...t3IM' http://localhost:8002/api/roots
+curl -v -d'username=foo@example.com' -d'password=bar' http://localhost:8002/auth/jwt/login  # -> "Set-Cookie: c2subauth=...t3IM; ..."
+curl -v -b'c2subauth=...t3IM' http://localhost:8002/api/roots
 ```
 
 ## Tools

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -27,6 +27,8 @@ sub_host_default = 'localhost:8002'
 """The default HTTP endpoint for the subscriber (URL host & port)."""
 
 
+# TODO: Add user authentication support.
+
 def get_roots(host=sub_host_default):
     """
     Get the list of available roots.

--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -21,6 +21,8 @@ except ImportError:
     blosc2_is_here = False
 
 
+# TODO: Add user authentication support.
+
 def split_dsname(dataset):
     ds = str(dataset)
     root_sep = ds.find('/')

--- a/caterva2/services/static/main.js
+++ b/caterva2/services/static/main.js
@@ -51,7 +51,9 @@ async function _submitForm(form, successURL, errorElementID, asJSON) {
     const json = await response.json();
     const errd = document.createElement("div");
     errd.setAttribute("class", "alert alert-danger");
-    errd.appendChild(document.createTextNode("Submission failed:"));
+    errd.appendChild(document.createTextNode("Submission failed: "));
+    errd.appendChild(document.createElement("code"))
+        .textContent = `${response.status} ${response.statusText}`;
     errd.appendChild(document.createElement("pre"))
         .textContent = JSON.stringify(json);
     error.replaceChildren(errd);

--- a/caterva2/services/static/main.js
+++ b/caterva2/services/static/main.js
@@ -51,10 +51,9 @@ async function _submitForm(form, successURL, errorElementID, asJSON) {
     const json = await response.json();
     const errd = document.createElement("div");
     errd.setAttribute("class", "alert alert-danger");
-    const errt = document.createTextNode("Submission failed:");
-    const errp = document.createElement("pre");
-    errp.textContent = JSON.stringify(json);
-    errd.replaceChildren(errt, errp);
+    errd.appendChild(document.createTextNode("Submission failed:"));
+    errd.appendChild(document.createElement("pre"))
+        .textContent = JSON.stringify(json);
     error.replaceChildren(errd);
 }
 

--- a/caterva2/services/static/main.js
+++ b/caterva2/services/static/main.js
@@ -25,9 +25,9 @@ function clearContent(elementID) {
     document.getElementById(elementID).innerHTML = "";
 }
 
-async function _submitForm(form, successURL, errorElementID, asJSON) {
-    const error = document.getElementById(errorElementID);
-    error.replaceChildren();  // empty the error view
+async function _submitForm(form, successURL, resultElementID, asJSON) {
+    const result = document.getElementById(resultElementID);
+    result.replaceChildren();  // empty the result view
 
     const params = {};
     for (const field of form.elements)
@@ -49,20 +49,20 @@ async function _submitForm(form, successURL, errorElementID, asJSON) {
     }
 
     const json = await response.json();
-    const errd = document.createElement("div");
-    errd.setAttribute("class", "alert alert-danger");
-    errd.appendChild(document.createTextNode("Submission failed: "));
-    errd.appendChild(document.createElement("code"))
+    const resd = document.createElement("div");
+    resd.setAttribute("class", "alert alert-danger");
+    resd.appendChild(document.createTextNode("Submission failed: "));
+    resd.appendChild(document.createElement("code"))
         .textContent = `${response.status} ${response.statusText}`;
-    errd.appendChild(document.createElement("pre"))
+    resd.appendChild(document.createElement("pre"))
         .textContent = JSON.stringify(json);
-    error.replaceChildren(errd);
+    result.replaceChildren(resd);
 }
 
-async function submitForm(form, successURL, errorElementID="error") {
-    return await _submitForm(form, successURL, errorElementID, false);
+async function submitForm(form, successURL, resultElementID="result") {
+    return await _submitForm(form, successURL, resultElementID, false);
 }
 
-async function submitFormAsJSON(form, successURL, errorElementID="error") {
-    return await _submitForm(form, successURL, errorElementID, true);
+async function submitFormAsJSON(form, successURL, resultElementID="result") {
+    return await _submitForm(form, successURL, resultElementID, true);
 }

--- a/caterva2/services/static/main.js
+++ b/caterva2/services/static/main.js
@@ -43,11 +43,6 @@ async function _submitForm(form, successURL, resultElementID, asJSON) {
                    : new URLSearchParams(params))},
     );
 
-    if (successURL && response.ok) {
-        window.location.href = successURL;
-        return;
-    }
-
     const resd = document.createElement("div");
     resd.setAttribute("class", ("alert alert-"
                                 + (response.ok ? "success" : "danger")));
@@ -55,10 +50,16 @@ async function _submitForm(form, successURL, resultElementID, asJSON) {
         response.ok ? "Submission succeeded: " : "Submission failed: "));
     resd.appendChild(document.createElement("code"))
         .textContent = `${response.status} ${response.statusText}`;
-    if (response.status != 204)  // 204 No Content, "!response.ok" is quieter
+    if (!response.ok)
         resd.appendChild(document.createElement("pre"))
             .textContent = JSON.stringify(await response.json());
     result.replaceChildren(resd);
+
+    if (successURL && response.ok) {
+        // Flash successful response for 2s, then go to success URL.
+        await new Promise(r => setTimeout(r, 2000));
+        window.location.href = successURL;
+    }
 }
 
 async function submitForm(form, successURL, resultElementID="result") {

--- a/caterva2/services/static/main.js
+++ b/caterva2/services/static/main.js
@@ -26,8 +26,8 @@ function clearContent(elementID) {
 }
 
 async function submitForm(form, errorElementID="error") {
-    const result = document.getElementById(errorElementID);
-    result.replaceChildren();  // empty the result view
+    const error = document.getElementById(errorElementID);
+    error.replaceChildren();  // empty the error view
 
     const params = {};
     for (const field of form.elements)
@@ -52,5 +52,5 @@ async function submitForm(form, errorElementID="error") {
     const errp = document.createElement("pre");
     errp.textContent = JSON.stringify(json);
     errd.replaceChildren(errt, errp);
-    result.replaceChildren(errd);
+    error.replaceChildren(errd);
 }

--- a/caterva2/services/static/main.js
+++ b/caterva2/services/static/main.js
@@ -25,8 +25,8 @@ function clearContent(elementID) {
     document.getElementById(elementID).innerHTML = "";
 }
 
-async function submitForm(form, errorElemId="error") {
-    const result = document.getElementById(errorElemId);
+async function submitForm(form, errorElementID="error") {
+    const result = document.getElementById(errorElementID);
     result.replaceChildren();  // empty the result view
 
     const params = {};

--- a/caterva2/services/static/main.js
+++ b/caterva2/services/static/main.js
@@ -25,7 +25,7 @@ function clearContent(elementID) {
     document.getElementById(elementID).innerHTML = "";
 }
 
-async function submitForm(form, errorElementID="error") {
+async function submitForm(form, successURL, errorElementID="error") {
     const error = document.getElementById(errorElementID);
     error.replaceChildren();  // empty the error view
 
@@ -41,7 +41,7 @@ async function submitForm(form, errorElementID="error") {
     );
 
     if (response.ok) {
-        window.location.href = "/";
+        window.location.href = successURL;
         return;
     }
 

--- a/caterva2/services/static/main.js
+++ b/caterva2/services/static/main.js
@@ -25,7 +25,7 @@ function clearContent(elementID) {
     document.getElementById(elementID).innerHTML = "";
 }
 
-async function submitForm(form, successURL, errorElementID="error") {
+async function _submitForm(form, successURL, errorElementID, asJSON) {
     const error = document.getElementById(errorElementID);
     error.replaceChildren();  // empty the error view
 
@@ -37,7 +37,10 @@ async function submitForm(form, successURL, errorElementID="error") {
     const response = await fetch(
         form.action, {
             method: form.method,
-            body: new URLSearchParams(params)},
+            headers: {'Content-Type': (asJSON ? 'application/json'
+                                       : 'application/x-www-form-urlencoded')},
+            body: (asJSON ? JSON.stringify(params)
+                   : new URLSearchParams(params))},
     );
 
     if (response.ok) {
@@ -53,4 +56,12 @@ async function submitForm(form, successURL, errorElementID="error") {
     errp.textContent = JSON.stringify(json);
     errd.replaceChildren(errt, errp);
     error.replaceChildren(errd);
+}
+
+async function submitForm(form, successURL, errorElementID="error") {
+    return await _submitForm(form, successURL, errorElementID, false);
+}
+
+async function submitFormAsJSON(form, successURL, errorElementID="error") {
+    return await _submitForm(form, successURL, errorElementID, true);
 }

--- a/caterva2/services/static/main.js
+++ b/caterva2/services/static/main.js
@@ -24,3 +24,33 @@ function activate(selector, trigger) {
 function clearContent(elementID) {
     document.getElementById(elementID).innerHTML = "";
 }
+
+async function submitForm(form, errorElemId="error") {
+    const result = document.getElementById(errorElemId);
+    result.replaceChildren();  // empty the result view
+
+    const params = {};
+    for (const field of form.elements)
+        if (field.name != "")
+            params[field.name] = field.value;
+
+    const response = await fetch(
+        form.action, {
+            method: form.method,
+            body: new URLSearchParams(params)},
+    );
+
+    if (response.ok) {
+        window.location.href = "/";
+        return;
+    }
+
+    const json = await response.json();
+    const errd = document.createElement("div");
+    errd.setAttribute("class", "alert alert-danger");
+    const errt = document.createTextNode("Submission failed:");
+    const errp = document.createElement("pre");
+    errp.textContent = JSON.stringify(json);
+    errd.replaceChildren(errt, errp);
+    result.replaceChildren(errd);
+}

--- a/caterva2/services/static/main.js
+++ b/caterva2/services/static/main.js
@@ -43,17 +43,19 @@ async function _submitForm(form, successURL, resultElementID, asJSON) {
                    : new URLSearchParams(params))},
     );
 
-    if (response.ok) {
+    if (successURL && response.ok) {
         window.location.href = successURL;
         return;
     }
 
     const resd = document.createElement("div");
-    resd.setAttribute("class", "alert alert-danger");
-    resd.appendChild(document.createTextNode("Submission failed: "));
+    resd.setAttribute("class", ("alert alert-"
+                                + (response.ok ? "success" : "danger")));
+    resd.appendChild(document.createTextNode(
+        response.ok ? "Submission succeeded: " : "Submission failed: "));
     resd.appendChild(document.createElement("code"))
         .textContent = `${response.status} ${response.statusText}`;
-    if (response.status != 204)  // 204 No Content
+    if (response.status != 204)  // 204 No Content, "!response.ok" is quieter
         resd.appendChild(document.createElement("pre"))
             .textContent = JSON.stringify(await response.json());
     result.replaceChildren(resd);

--- a/caterva2/services/static/main.js
+++ b/caterva2/services/static/main.js
@@ -48,14 +48,14 @@ async function _submitForm(form, successURL, resultElementID, asJSON) {
         return;
     }
 
-    const json = await response.json();
     const resd = document.createElement("div");
     resd.setAttribute("class", "alert alert-danger");
     resd.appendChild(document.createTextNode("Submission failed: "));
     resd.appendChild(document.createElement("code"))
         .textContent = `${response.status} ${response.statusText}`;
-    resd.appendChild(document.createElement("pre"))
-        .textContent = JSON.stringify(json);
+    if (response.status != 204)  // 204 No Content
+        resd.appendChild(document.createElement("pre"))
+            .textContent = JSON.stringify(await response.json());
     result.replaceChildren(resd);
 }
 

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -160,10 +160,14 @@ def follow(name: str):
 # HTTP API
 #
 
+def user_auth_enabled():
+    return os.environ.get(users.SECRET_TOKEN_ENVVAR)
+
+
 @contextlib.asynccontextmanager
 async def lifespan(app: FastAPI):
     # Initialize the (users) database
-    if os.environ.get(users.SECRET_TOKEN_ENVVAR):
+    if user_auth_enabled():
         await db.create_db_and_tables(statedir)
 
     # Initialize roots from the broker
@@ -211,7 +215,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
-if os.environ.get(users.SECRET_TOKEN_ENVVAR):
+if user_auth_enabled():
     app.include_router(
         users.fastapi_users.get_auth_router(users.auth_backend),
         prefix="/auth/jwt", tags=["auth"]

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -166,6 +166,9 @@ def user_auth_enabled():
 
 current_active_user = (users.current_active_user if user_auth_enabled()
                        else (lambda: None))
+optional_user = (users.fastapi_users.current_user(optional=True)
+                 if user_auth_enabled()
+                 else (lambda: None))
 
 
 @contextlib.asynccontextmanager
@@ -535,8 +538,12 @@ async def download_data(path: str):
 #
 
 @app.get("/login", response_class=HTMLResponse)
-async def html_login(request: Request):
-    return templates.TemplateResponse(request, "login.html")
+async def html_login(
+        request: Request,
+        opt_user: db.User = Depends(optional_user)
+):
+    context = {'username': opt_user.email} if opt_user else {}
+    return templates.TemplateResponse(request, "login.html", context)
 
 
 """

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -563,15 +563,16 @@ def home(request, roots=None, search=None, context=None):
     return templates.TemplateResponse(request, "home.html", context)
 
 
-@app.get("/", response_class=HTMLResponse,
-         dependencies=[Depends(current_active_user)])
+@app.get("/", response_class=HTMLResponse)
 async def html_home(
     request: Request,
     # Query parameters
     roots: list[str] = fastapi.Query([]),
     search: str = '',
+    user: db.User = Depends(current_active_user),
 ):
-    return home(request, roots, search)
+    context = {'username': user.email} if user else {}
+    return home(request, roots, search, context)
 
 
 @app.get("/htmx/root-list/",

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -563,9 +563,13 @@ async def html_home(
     # Query parameters
     roots: list[str] = fastapi.Query([]),
     search: str = '',
-    user: db.User = Depends(current_active_user),
+    opt_user: db.User = Depends(optional_user),
 ):
-    context = {'username': user.email} if user else {}
+    # Redirect to login page if user not authenticated.
+    if user_auth_enabled() and not opt_user:
+        return RedirectResponse("/login", status_code=307)
+
+    context = {'username': opt_user.email} if opt_user else {}
     return home(request, roots, search, context)
 
 

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -549,6 +549,18 @@ if user_auth_enabled():
         context = {'username': opt_user.email} if opt_user else {}
         return templates.TemplateResponse(request, "login.html", context)
 
+    @app.get("/logout", response_class=HTMLResponse)
+    async def html_logout(
+            request: Request,
+            opt_user: db.User = Depends(optional_user)
+    ):
+        # Redirect to root page if already not authenticated.
+        if user_auth_enabled() and not opt_user:
+            return RedirectResponse("/", status_code=307)
+
+        context = {'username': opt_user.email} if opt_user else {}
+        return templates.TemplateResponse(request, "logout.html", context)
+
 
 def home(request, roots=None, search=None, context=None):
     context = context or {}

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -546,19 +546,6 @@ async def html_login(
     return templates.TemplateResponse(request, "login.html", context)
 
 
-"""
-@app.post("/login")
-async def html_login_post(request: Request):
-    error = False
-    if error:
-        context = {}
-        return templates.TemplateResponse(request, "login.html", context)
-
-    # TODO Set Cookie
-    return RedirectResponse("/", status_code=302)
-"""
-
-
 def home(request, roots=None, search=None, context=None):
     context = context or {}
 

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -168,7 +168,9 @@ current_active_user = (users.current_active_user if user_auth_enabled()
                        else (lambda: None))
 """Depend on this if the route needs an authenticated user (if enabled)."""
 
-optional_user = (users.fastapi_users.current_user(optional=True)
+optional_user = (users.fastapi_users.current_user(
+                     optional=True,
+                     verified=False)  # TODO: set when verification works
                  if user_auth_enabled()
                  else (lambda: None))
 """Depend on this if the route may do something with no authentication."""

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -15,7 +15,7 @@ import pickle
 
 # FastAPI
 from fastapi import FastAPI, Request, responses
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 import fastapi
@@ -500,6 +500,24 @@ async def download_data(path: str):
 #
 # HTML interface
 #
+
+@app.get("/login", response_class=HTMLResponse)
+async def html_login(request: Request):
+    return templates.TemplateResponse(request, "login.html")
+
+
+"""
+@app.post("/login")
+async def html_login_post(request: Request):
+    error = False
+    if error:
+        context = {}
+        return templates.TemplateResponse(request, "login.html", context)
+
+    # TODO Set Cookie
+    return RedirectResponse("/", status_code=302)
+"""
+
 
 def home(request, roots=None, search=None, context=None):
     context = context or {}

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -31,7 +31,7 @@ import uvicorn
 # Project
 from caterva2 import utils, api_utils, models
 from caterva2.services import srv_utils
-from caterva2.services.subscriber import db, schemas
+from caterva2.services.subscriber import db, schemas, users
 from .plugins import tomography
 
 
@@ -163,7 +163,7 @@ def follow(name: str):
 @contextlib.asynccontextmanager
 async def lifespan(app: FastAPI):
     # Initialize the (users) database
-    if os.environ.get(db.SECRET_TOKEN_ENVVAR):
+    if os.environ.get(users.SECRET_TOKEN_ENVVAR):
         await db.create_db_and_tables(statedir)
 
     # Initialize roots from the broker

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -166,9 +166,12 @@ def user_auth_enabled():
 
 current_active_user = (users.current_active_user if user_auth_enabled()
                        else (lambda: None))
+"""Depend on this if the route needs an authenticated user (if enabled)."""
+
 optional_user = (users.fastapi_users.current_user(optional=True)
                  if user_auth_enabled()
                  else (lambda: None))
+"""Depend on this if the route may do something with no authentication."""
 
 
 @contextlib.asynccontextmanager

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -31,7 +31,7 @@ import uvicorn
 # Project
 from caterva2 import utils, api_utils, models
 from caterva2.services import srv_utils
-from caterva2.services.subscriber import db
+from caterva2.services.subscriber import db, schemas
 from .plugins import tomography
 
 

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -237,6 +237,7 @@ if user_auth_enabled():
             schemas.UserRead, schemas.UserCreate),
         prefix="/auth", tags=["auth"],
     )
+    # TODO: Support user verification, allow password reset and user deletion.
 app.mount("/static", StaticFiles(directory=BASE_DIR / "static"))
 templates = Jinja2Templates(directory=BASE_DIR / "templates")
 
@@ -570,6 +571,8 @@ if user_auth_enabled():
     ):
         context = {'username': opt_user.email} if opt_user else {}
         return templates.TemplateResponse(request, "register.html", context)
+
+    # TODO: Support user verification, allow password reset and user deletion.
 
 
 def home(request, roots=None, search=None, context=None):

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -561,6 +561,14 @@ if user_auth_enabled():
         context = {'username': opt_user.email} if opt_user else {}
         return templates.TemplateResponse(request, "logout.html", context)
 
+    @app.get("/register", response_class=HTMLResponse)
+    async def html_register(
+            request: Request,
+            opt_user: db.User = Depends(optional_user)
+    ):
+        context = {'username': opt_user.email} if opt_user else {}
+        return templates.TemplateResponse(request, "register.html", context)
+
 
 def home(request, roots=None, search=None, context=None):
     context = context or {}

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -537,13 +537,14 @@ async def download_data(path: str):
 # HTML interface
 #
 
-@app.get("/login", response_class=HTMLResponse)
-async def html_login(
-        request: Request,
-        opt_user: db.User = Depends(optional_user)
-):
-    context = {'username': opt_user.email} if opt_user else {}
-    return templates.TemplateResponse(request, "login.html", context)
+if user_auth_enabled():
+    @app.get("/login", response_class=HTMLResponse)
+    async def html_login(
+            request: Request,
+            opt_user: db.User = Depends(optional_user)
+    ):
+        context = {'username': opt_user.email} if opt_user else {}
+        return templates.TemplateResponse(request, "login.html", context)
 
 
 def home(request, roots=None, search=None, context=None):

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -211,6 +211,16 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+if os.environ.get(users.SECRET_TOKEN_ENVVAR):
+    app.include_router(
+        users.fastapi_users.get_auth_router(users.auth_backend),
+        prefix="/auth/jwt", tags=["auth"]
+    )
+    app.include_router(
+        users.fastapi_users.get_register_router(
+            schemas.UserRead, schemas.UserCreate),
+        prefix="/auth", tags=["auth"],
+    )
 app.mount("/static", StaticFiles(directory=BASE_DIR / "static"))
 templates = Jinja2Templates(directory=BASE_DIR / "templates")
 

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -264,7 +264,7 @@ def get_root(name):
 
 
 @app.post('/api/subscribe/{name}',
-         dependencies=[Depends(current_active_user)])
+          dependencies=[Depends(current_active_user)])
 async def post_subscribe(name: str):
     """
     Subscribe to a root.

--- a/caterva2/services/subscriber/db.py
+++ b/caterva2/services/subscriber/db.py
@@ -14,7 +14,7 @@ https://fastapi-users.github.io/fastapi-users/latest/configuration/full-example/
 
 The database should only be used if a (non-empty) secret token for the
 management of users is set in the environment variable named by
-`SECRET_TOKEN_ENVVAR`.
+`caterva2.services.subscriber.users.SECRET_TOKEN_ENVVAR`.
 
 The database will be stored in SQLite format inside of the state directory
 given to `create_db_and_tables()`.
@@ -27,9 +27,6 @@ from fastapi import Depends
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID, SQLAlchemyUserDatabase
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
-
-
-SECRET_TOKEN_ENVVAR = 'CATERVA2_AUTH_SECRET'
 
 
 class Base(DeclarativeBase):

--- a/caterva2/services/subscriber/db.py
+++ b/caterva2/services/subscriber/db.py
@@ -11,6 +11,13 @@
 
 Used for user authentication (for the moment), based on FastAPI Users example:
 https://fastapi-users.github.io/fastapi-users/latest/configuration/full-example/
+
+The database should only be used if a (non-empty) secret token for the
+management of users is set in the environment variable named by
+`SECRET_TOKEN_ENVVAR`.
+
+The database will be stored in SQLite format inside of the state directory
+given to `create_db_and_tables()`.
 """
 
 from pathlib import Path

--- a/caterva2/services/subscriber/db.py
+++ b/caterva2/services/subscriber/db.py
@@ -1,0 +1,55 @@
+###############################################################################
+# Caterva2 - On demand access to remote Blosc2 data repositories
+#
+# Copyright (c) 2023 The Blosc Developers <blosc@blosc.org>
+# https://www.blosc.org
+# License: GNU Affero General Public License v3.0
+# See LICENSE.txt for details about copyright and rights to use.
+###############################################################################
+
+"""Subscriber database.
+
+Used for user authentication (for the moment), based on FastAPI Users example:
+https://fastapi-users.github.io/fastapi-users/latest/configuration/full-example/
+"""
+
+from pathlib import Path
+from typing import AsyncGenerator
+
+from fastapi import Depends
+from fastapi_users.db import SQLAlchemyBaseUserTableUUID, SQLAlchemyUserDatabase
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+
+SECRET_TOKEN_ENVVAR = 'CATERVA2_AUTH_SECRET'
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class User(SQLAlchemyBaseUserTableUUID, Base):
+    pass
+
+
+engine = None
+async_session_maker = None
+
+
+async def create_db_and_tables(statedir: Path):
+    global engine, async_session_maker  # keep global as in original example
+    engine = create_async_engine(f'sqlite+aiosqlite:///{statedir}/db.sqlite')
+    async_session_maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
+    async with async_session_maker() as session:
+        yield session
+
+
+async def get_user_db(session: AsyncSession = Depends(get_async_session)):
+    yield SQLAlchemyUserDatabase(session, User)

--- a/caterva2/services/subscriber/schemas.py
+++ b/caterva2/services/subscriber/schemas.py
@@ -1,0 +1,30 @@
+###############################################################################
+# Caterva2 - On demand access to remote Blosc2 data repositories
+#
+# Copyright (c) 2023 The Blosc Developers <blosc@blosc.org>
+# https://www.blosc.org
+# License: GNU Affero General Public License v3.0
+# See LICENSE.txt for details about copyright and rights to use.
+###############################################################################
+
+"""Subscriber schemas.
+
+Used for user authentication (for the moment), based on FastAPI Users example:
+https://fastapi-users.github.io/fastapi-users/latest/configuration/full-example/
+"""
+
+import uuid
+
+from fastapi_users import schemas
+
+
+class UserRead(schemas.BaseUser[uuid.UUID]):
+    pass
+
+
+class UserCreate(schemas.BaseUserCreate):
+    pass
+
+
+class UserUpdate(schemas.BaseUserUpdate):
+    pass

--- a/caterva2/services/subscriber/users.py
+++ b/caterva2/services/subscriber/users.py
@@ -64,7 +64,10 @@ async def get_user_manager(user_db: SQLAlchemyUserDatabase = Depends(get_user_db
     yield UserManager(user_db)
 
 
-cookie_transport = CookieTransport(cookie_secure=False)  # TODO: only for testing
+cookie_transport = CookieTransport(
+    cookie_name='c2subauth',
+    cookie_secure=False,  # TODO: only for testing
+)
 
 
 def get_jwt_strategy() -> JWTStrategy:

--- a/caterva2/services/subscriber/users.py
+++ b/caterva2/services/subscriber/users.py
@@ -1,0 +1,83 @@
+###############################################################################
+# Caterva2 - On demand access to remote Blosc2 data repositories
+#
+# Copyright (c) 2023 The Blosc Developers <blosc@blosc.org>
+# https://www.blosc.org
+# License: GNU Affero General Public License v3.0
+# See LICENSE.txt for details about copyright and rights to use.
+###############################################################################
+
+"""Subscriber user management.
+
+Used for user authentication (for the moment), based on FastAPI Users example:
+https://fastapi-users.github.io/fastapi-users/latest/configuration/full-example/
+
+The database should only be used if a (non-empty) secret token for the
+management of users is set in the environment variable named by
+`SECRET_TOKEN_ENVVAR`.
+"""
+
+import functools
+import os
+import uuid
+from typing import Optional
+
+from fastapi import Depends, Request
+from fastapi_users import BaseUserManager, FastAPIUsers, UUIDIDMixin
+from fastapi_users.authentication import (
+    AuthenticationBackend,
+    CookieTransport,
+    JWTStrategy,
+)
+from fastapi_users.db import SQLAlchemyUserDatabase
+
+from .db import User, get_user_db
+
+
+SECRET_TOKEN_ENVVAR = 'CATERVA2_AUTH_SECRET'
+
+
+class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
+    @functools.cached_property
+    def reset_password_token_secret(self):
+        return os.environ.get(SECRET_TOKEN_ENVVAR)
+
+    @functools.cached_property
+    def verification_token_secret(self):
+        return os.environ.get(SECRET_TOKEN_ENVVAR)
+
+    async def on_after_register(self, user: User, request: Optional[Request] = None):
+        print(f"User {user.id} has registered.")
+
+    async def on_after_forgot_password(
+        self, user: User, token: str, request: Optional[Request] = None
+    ):
+        print(f"User {user.id} has forgot their password. Reset token: {token}")
+
+    async def on_after_request_verify(
+        self, user: User, token: str, request: Optional[Request] = None
+    ):
+        print(f"Verification requested for user {user.id}. Verification token: {token}")
+
+
+async def get_user_manager(user_db: SQLAlchemyUserDatabase = Depends(get_user_db)):
+    yield UserManager(user_db)
+
+
+cookie_transport = CookieTransport(cookie_secure=False)  # TODO: only for testing
+
+
+def get_jwt_strategy() -> JWTStrategy:
+    return JWTStrategy(secret=os.environ.get(SECRET_TOKEN_ENVVAR),
+                       lifetime_seconds=3600)
+
+
+auth_backend = AuthenticationBackend(
+    name="jwt",
+    transport=cookie_transport,
+    get_strategy=get_jwt_strategy,
+)
+
+fastapi_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend])
+
+current_active_user = fastapi_users.current_user(active=True)

--- a/caterva2/services/subscriber/users.py
+++ b/caterva2/services/subscriber/users.py
@@ -68,6 +68,8 @@ cookie_transport = CookieTransport(cookie_secure=False)  # TODO: only for testin
 
 
 def get_jwt_strategy() -> JWTStrategy:
+    # The token itself is valid for an hour, even after an explicit logout
+    # (however the cookie transport would delete the cookie anyway).
     return JWTStrategy(secret=os.environ.get(SECRET_TOKEN_ENVVAR),
                        lifetime_seconds=3600)
 

--- a/caterva2/services/subscriber/users.py
+++ b/caterva2/services/subscriber/users.py
@@ -46,6 +46,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     def verification_token_secret(self):
         return os.environ.get(SECRET_TOKEN_ENVVAR)
 
+    # TODO: Replace with actual functionality;
+    # support user verification, allow password reset and user deletion.
+
     async def on_after_register(self, user: User, request: Optional[Request] = None):
         print(f"User {user.id} has registered.")
 

--- a/caterva2/services/subscriber/users.py
+++ b/caterva2/services/subscriber/users.py
@@ -85,4 +85,7 @@ auth_backend = AuthenticationBackend(
 
 fastapi_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend])
 
-current_active_user = fastapi_users.current_user(active=True)
+current_active_user = fastapi_users.current_user(
+    active=True,
+    verified=False,  # TODO: set when verification works
+)

--- a/caterva2/services/templates/home.html
+++ b/caterva2/services/templates/home.html
@@ -14,9 +14,7 @@
 
 <!-- Main section -->
 <div id="page">
-    <div hx-get="{{ roots_url }}" hx-trigger="load">
-        {% if username %}Logged in as: {{ username }}<br><a href="/logout">Logout</a>{% endif %}
-    </div>
+    <div hx-get="{{ roots_url }}" hx-trigger="load"></div>
     <div id="path-list-wrapper">
         {% include 'loading.html' %}
         <div id="path-list"{% if paths_url %} hx-get="{{ paths_url }}" hx-trigger="load"{% endif %}>
@@ -26,6 +24,7 @@
         {% include 'loading.html' %}
         <div id="meta"{% if meta_url %} hx-get="{{ meta_url }}" hx-trigger="load"{% endif %}></div>
     </div>
+    {% if username %}<p>Logged in as: {{ username }}<br><a href="/logout">Logout</a></p>{% endif %}
 </div>
 
 </body>

--- a/caterva2/services/templates/home.html
+++ b/caterva2/services/templates/home.html
@@ -14,7 +14,9 @@
 
 <!-- Main section -->
 <div id="page">
-    <div hx-get="{{ roots_url }}" hx-trigger="load"></div>
+    <div hx-get="{{ roots_url }}" hx-trigger="load">
+        {% if username %}Logged in as: {{ username }}<br><a href="/logout">Logout</a>{% endif %}
+    </div>
     <div id="path-list-wrapper">
         {% include 'loading.html' %}
         <div id="path-list"{% if paths_url %} hx-get="{{ paths_url }}" hx-trigger="load"{% endif %}>

--- a/caterva2/services/templates/home.html
+++ b/caterva2/services/templates/home.html
@@ -13,6 +13,12 @@
 <body class="vh-120">
 
 <!-- Main section -->
+{% if username %}
+<div class="alert alert-info">
+    Logged in as {{ username }}.
+    <a href="/logout">Logout</a>.
+</div>
+{% endif %}
 <div id="page">
     <div hx-get="{{ roots_url }}" hx-trigger="load"></div>
     <div id="path-list-wrapper">
@@ -24,7 +30,6 @@
         {% include 'loading.html' %}
         <div id="meta"{% if meta_url %} hx-get="{{ meta_url }}" hx-trigger="load"{% endif %}></div>
     </div>
-    {% if username %}<p>Logged in as: {{ username }}<br><a href="/logout">Logout</a></p>{% endif %}
 </div>
 
 </body>

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="icon" type="image/png" href="/static/logo-caterva2-16x16.png">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+
+    <script src="/static/main.js"></script>
+    <link href="/static/main.css" rel="stylesheet">
+</head>
+
+<body class="vh-120">
+
+<!-- Main section -->
+<div id="page">
+    <form method="post" id="id_form">
+        <div class="mb-3">
+            <label for="id_username" class="form-label">Username</label>
+            <input type="username" class="form-control" id="id_username">
+        </div>
+        <div class="mb-3">
+            <label for="id_password" class="form-label">Password</label>
+            <input type="password" class="form-control" id="id_password">
+        </div>
+        <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+</div>
+
+<script>
+document.getElementById("id_form").addEventListener("submit", (ev) => {
+    ev.preventDefault();
+    // TODO await fetch
+});
+</script>
+
+</body>
+</html>

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -33,9 +33,23 @@
 </div>
 
 <script>
-document.getElementById("id_form").addEventListener("submit", (ev) => {
+document.getElementById("id_form").addEventListener("submit", async (ev) => {
     ev.preventDefault();
-    // TODO await fetch
+
+    const username = document.getElementById("id_username").value;
+    const password = document.getElementById("id_password").value;
+    const response = await fetch(
+        "/auth/jwt/login", {
+            method: "POST",
+            body: new URLSearchParams({username: username,
+                                       password: password})},
+    );
+    const json = await response.json();
+
+    if (response.ok)
+        window.location.href = "/";
+
+    // TODO: Show error on failure.
 });
 </script>
 

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -19,7 +19,7 @@
 </div>
 {% endif %}
 <div id="page">
-    <form action="/auth/jwt/login" method="post" id="id_form">
+    <form action="/auth/jwt/login" method="post" onsubmit="submitForm(); return false">
         <div class="mb-3">
             <label for="id_username" class="form-label">Username</label>
             <input type="username" name="username" class="form-control" id="id_username">
@@ -34,9 +34,7 @@
 <div id="result"></div>
 
 <script>
-document.getElementById("id_form").addEventListener("submit", async (ev) => {
-    ev.preventDefault();
-
+async function submitForm() {
     const result = document.getElementById("result");
     result.replaceChildren();  // empty the result view
 
@@ -57,12 +55,12 @@ document.getElementById("id_form").addEventListener("submit", async (ev) => {
     const json = await response.json();
     const errd = document.createElement("div");
     errd.setAttribute("class", "alert alert-danger");
-    const errt = document.createTextNode("Authentication failed:");
+    const errt = document.createTextNode("Submission failed:");
     const errp = document.createElement("pre");
     errp.textContent = JSON.stringify(json);
     errd.replaceChildren(errt, errp);
     result.replaceChildren(errd);
-});
+}
 </script>
 
 </body>

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <title>User login</title>
+
     <link rel="icon" type="image/png" href="/static/logo-caterva2-16x16.png">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -31,10 +31,14 @@
         <button type="submit" class="btn btn-primary">Login</button>
     </form>
 </div>
+<div id="result"></div>
 
 <script>
 document.getElementById("id_form").addEventListener("submit", async (ev) => {
     ev.preventDefault();
+
+    const result = document.getElementById("result");
+    result.replaceChildren();  // empty the result view
 
     const username = document.getElementById("id_username").value;
     const password = document.getElementById("id_password").value;
@@ -44,12 +48,20 @@ document.getElementById("id_form").addEventListener("submit", async (ev) => {
             body: new URLSearchParams({username: username,
                                        password: password})},
     );
-    const json = await response.json();
 
-    if (response.ok)
+    if (response.ok) {
         window.location.href = "/";
+        return;
+    }
 
-    // TODO: Show error on failure.
+    const json = await response.json();
+    const errd = document.createElement("div");
+    errd.setAttribute("class", "alert alert-danger");
+    const errt = document.createTextNode("Authentication failed:");
+    const errp = document.createElement("pre");
+    errp.textContent = JSON.stringify(json);
+    errd.replaceChildren(errt, errp);
+    result.replaceChildren(errd);
 });
 </script>
 

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -30,7 +30,7 @@
     </form>
 </div>
 <p><a href="/register">Register as a new user</a></p>
-<div id="error"></div>
+<div id="result"></div>
 
 </body>
 </html>

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -19,16 +19,16 @@
 </div>
 {% endif %}
 <div id="page">
-    <form method="post" id="id_form">
+    <form action="/auth/jwt/login" method="post" id="id_form">
         <div class="mb-3">
             <label for="id_username" class="form-label">Username</label>
-            <input type="username" class="form-control" id="id_username">
+            <input type="username" name="username" class="form-control" id="id_username">
         </div>
         <div class="mb-3">
             <label for="id_password" class="form-label">Password</label>
-            <input type="password" class="form-control" id="id_password">
+            <input type="password" name="password" class="form-control" id="id_password">
         </div>
-        <button type="submit" class="btn btn-primary">Submit</button>
+        <button type="submit" class="btn btn-primary">Login</button>
     </form>
 </div>
 

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -19,7 +19,7 @@
 </div>
 {% endif %}
 <div id="page">
-    <form action="/auth/jwt/login" method="post" onsubmit="submitForm(); return false">
+    <form action="/auth/jwt/login" method="post" onsubmit="submitForm(this); return false">
         <div class="mb-3">
             <label for="id_username" class="form-label">Username</label>
             <input type="username" name="username" class="form-control" id="id_username">
@@ -34,15 +34,15 @@
 <div id="result"></div>
 
 <script>
-async function submitForm() {
+async function submitForm(form) {
     const result = document.getElementById("result");
     result.replaceChildren();  // empty the result view
 
     const username = document.getElementById("id_username").value;
     const password = document.getElementById("id_password").value;
     const response = await fetch(
-        "/auth/jwt/login", {
-            method: "POST",
+        form.action, {
+            method: form.method,
             body: new URLSearchParams({username: username,
                                        password: password})},
     );

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -19,7 +19,7 @@
 </div>
 {% endif %}
 <div id="page">
-    <form action="/auth/jwt/login" method="post" onsubmit="submitForm(this); return false">
+    <form action="/auth/jwt/login" method="post" onsubmit="submitForm(this, '/'); return false">
         <label class="form-label">Username
             <input type="username" name="username" class="form-control"></label>
         <label class="form-label">Password

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -29,37 +29,5 @@
 </div>
 <div id="error"></div>
 
-<script>
-async function submitForm(form, errorElemId="error") {
-    const result = document.getElementById(errorElemId);
-    result.replaceChildren();  // empty the result view
-
-    const params = {};
-    for (const field of form.elements)
-        if (field.name != "")
-            params[field.name] = field.value;
-
-    const response = await fetch(
-        form.action, {
-            method: form.method,
-            body: new URLSearchParams(params)},
-    );
-
-    if (response.ok) {
-        window.location.href = "/";
-        return;
-    }
-
-    const json = await response.json();
-    const errd = document.createElement("div");
-    errd.setAttribute("class", "alert alert-danger");
-    const errt = document.createTextNode("Submission failed:");
-    const errp = document.createElement("pre");
-    errp.textContent = JSON.stringify(json);
-    errd.replaceChildren(errt, errp);
-    result.replaceChildren(errd);
-}
-</script>
-
 </body>
 </html>

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -20,14 +20,10 @@
 {% endif %}
 <div id="page">
     <form action="/auth/jwt/login" method="post" onsubmit="submitForm(this); return false">
-        <div class="mb-3">
-            <label for="id_username" class="form-label">Username</label>
-            <input type="username" name="username" class="form-control" id="id_username">
-        </div>
-        <div class="mb-3">
-            <label for="id_password" class="form-label">Password</label>
-            <input type="password" name="password" class="form-control" id="id_password">
-        </div>
+        <label class="form-label">Username
+            <input type="username" name="username" class="form-control"></label>
+        <label class="form-label">Password
+            <input type="password" name="password" class="form-control"></label>
         <button type="submit" class="btn btn-primary">Login</button>
     </form>
 </div>

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -27,6 +27,7 @@
         <button type="submit" class="btn btn-primary">Login</button>
     </form>
 </div>
+<p><a href="/register">Register as a new user</a></p>
 <div id="error"></div>
 
 </body>

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -12,6 +12,12 @@
 <body class="vh-120">
 
 <!-- Main section -->
+{% if username %}
+<div class="alert alert-info">
+    <strong>Note:</strong> You are already logged in as {{ username }}.
+    <a href="/logout">Logout</a>.
+</div>
+{% endif %}
 <div id="page">
     <form method="post" id="id_form">
         <div class="mb-3">

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -20,7 +20,7 @@
 {% endif %}
 <div id="page">
     <form action="/auth/jwt/login" method="post" onsubmit="submitForm(this, '/'); return false">
-        <label class="form-label">Username
+        <label class="form-label">Username (e-mail)
             <input type="username" name="username" class="form-control"></label>
         <label class="form-label">Password
             <input type="password" name="password" class="form-control"></label>

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -27,11 +27,11 @@
         <button type="submit" class="btn btn-primary">Login</button>
     </form>
 </div>
-<div id="result"></div>
+<div id="error"></div>
 
 <script>
-async function submitForm(form) {
-    const result = document.getElementById("result");
+async function submitForm(form, errorElemId="error") {
+    const result = document.getElementById(errorElemId);
     result.replaceChildren();  // empty the result view
 
     const params = {};

--- a/caterva2/services/templates/login.html
+++ b/caterva2/services/templates/login.html
@@ -38,13 +38,15 @@ async function submitForm(form) {
     const result = document.getElementById("result");
     result.replaceChildren();  // empty the result view
 
-    const username = document.getElementById("id_username").value;
-    const password = document.getElementById("id_password").value;
+    const params = {};
+    for (const field of form.elements)
+        if (field.name != "")
+            params[field.name] = field.value;
+
     const response = await fetch(
         form.action, {
             method: form.method,
-            body: new URLSearchParams({username: username,
-                                       password: password})},
+            body: new URLSearchParams(params)},
     );
 
     if (response.ok) {

--- a/caterva2/services/templates/logout.html
+++ b/caterva2/services/templates/logout.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <title>User logout</title>
+
     <link rel="icon" type="image/png" href="/static/logo-caterva2-16x16.png">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>

--- a/caterva2/services/templates/logout.html
+++ b/caterva2/services/templates/logout.html
@@ -18,38 +18,11 @@
 </div>
 {% endif %}
 <div id="page">
-    <form action="/auth/jwt/logout" method="post" id="id_form">
+    <form action="/auth/jwt/logout" method="post" onsubmit="submitForm(this); return false">
         <button type="submit" class="btn btn-primary">Logout</button>
     </form>
 </div>
-<div id="result"></div>
-
-<script>
-document.getElementById("id_form").addEventListener("submit", async (ev) => {
-    ev.preventDefault();
-
-    const result = document.getElementById("result");
-    result.replaceChildren();  // empty the result view
-
-    const response = await fetch(
-        "/auth/jwt/logout", {method: "POST"},
-    );
-
-    if (response.ok) {
-        window.location.href = "/";
-        return;
-    }
-
-    const json = await response.json();
-    const errd = document.createElement("div");
-    errd.setAttribute("class", "alert alert-danger");
-    const errt = document.createTextNode("Authentication failed:");
-    const errp = document.createElement("pre");
-    errp.textContent = JSON.stringify(json);
-    errd.replaceChildren(errt, errp);
-    result.replaceChildren(errd);
-});
-</script>
+<div id="error"></div>
 
 </body>
 </html>

--- a/caterva2/services/templates/logout.html
+++ b/caterva2/services/templates/logout.html
@@ -18,7 +18,7 @@
 </div>
 {% endif %}
 <div id="page">
-    <form action="/auth/jwt/logout" method="post" onsubmit="submitForm(this); return false">
+    <form action="/auth/jwt/logout" method="post" onsubmit="submitForm(this, '/'); return false">
         <button type="submit" class="btn btn-primary">Logout</button>
     </form>
 </div>

--- a/caterva2/services/templates/logout.html
+++ b/caterva2/services/templates/logout.html
@@ -24,7 +24,7 @@
         <button type="submit" class="btn btn-primary">Logout</button>
     </form>
 </div>
-<div id="error"></div>
+<div id="result"></div>
 
 </body>
 </html>

--- a/caterva2/services/templates/logout.html
+++ b/caterva2/services/templates/logout.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="icon" type="image/png" href="/static/logo-caterva2-16x16.png">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+
+    <script src="/static/main.js"></script>
+    <link href="/static/main.css" rel="stylesheet">
+</head>
+
+<body class="vh-120">
+
+<!-- Main section -->
+{% if username %}
+<div class="alert alert-info">
+    Logged in as {{ username }}.
+</div>
+{% endif %}
+<div id="page">
+    <form action="/auth/jwt/logout" method="post" id="id_form">
+        <button type="submit" class="btn btn-primary">Logout</button>
+    </form>
+</div>
+<div id="result"></div>
+
+<script>
+document.getElementById("id_form").addEventListener("submit", async (ev) => {
+    ev.preventDefault();
+
+    const result = document.getElementById("result");
+    result.replaceChildren();  // empty the result view
+
+    const response = await fetch(
+        "/auth/jwt/logout", {method: "POST"},
+    );
+
+    if (response.ok) {
+        window.location.href = "/";
+        return;
+    }
+
+    const json = await response.json();
+    const errd = document.createElement("div");
+    errd.setAttribute("class", "alert alert-danger");
+    const errt = document.createTextNode("Authentication failed:");
+    const errp = document.createElement("pre");
+    errp.textContent = JSON.stringify(json);
+    errd.replaceChildren(errt, errp);
+    result.replaceChildren(errd);
+});
+</script>
+
+</body>
+</html>

--- a/caterva2/services/templates/register.html
+++ b/caterva2/services/templates/register.html
@@ -28,7 +28,7 @@
         <button type="submit" class="btn btn-primary">Register</button>
     </form>
 </div>
-<div id="error"></div>
+<div id="result"></div>
 
 </body>
 </html>

--- a/caterva2/services/templates/register.html
+++ b/caterva2/services/templates/register.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <title>User registration</title>
+
     <link rel="icon" type="image/png" href="/static/logo-caterva2-16x16.png">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>

--- a/caterva2/services/templates/register.html
+++ b/caterva2/services/templates/register.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="icon" type="image/png" href="/static/logo-caterva2-16x16.png">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+
+    <script src="/static/main.js"></script>
+    <link href="/static/main.css" rel="stylesheet">
+</head>
+
+<body class="vh-120">
+
+<!-- Main section -->
+{% if username %}
+<div class="alert alert-info">
+    <strong>Note:</strong> You are already logged in as {{ username }}.
+</div>
+{% endif %}
+<div id="page">
+    <form action="/auth/register" method="post" onsubmit="submitFormAsJSON(this, '/login'); return false">
+        <label class="form-label">E-mail (username)
+            <input type="username" name="email" class="form-control"></label>
+        <label class="form-label">Password
+            <input type="password" name="password" class="form-control"></label>
+        <button type="submit" class="btn btn-primary">Register</button>
+    </form>
+</div>
+<div id="error"></div>
+
+</body>
+</html>

--- a/caterva2/tests/services.py
+++ b/caterva2/tests/services.py
@@ -92,7 +92,7 @@ def make_get_http(host, path='/'):
         url = f'http://{host}{path}'
         try:
             r = httpx.get(url, timeout=0.5)
-            return r.status_code == 200
+            return 100 <= r.status_code < 500  # not internal errors
         except httpx.ConnectError:
             return False
     check.__name__ = f'get_http_{host}'  # more descriptive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,10 @@ base-services = [
     "watchfiles",
 ]
 subscriber = [
+    "aiosqlite",
     "caterva2[base-services]",
+    "fastapi-users[sqlalchemy]",
+    "uvicorn[standard]",
     "furl",
     "jinja2",
     "markdown",


### PR DESCRIPTION
This adds experimental FastAPI Users-based machinery to require user authentication for API and Web client operations. User registration is possible (without mail verification yet). Authentication tokens are transported with cookies, since that is easier for web browser usage, the primary target of this initial implementation. See the readme for more information.

Please note that this is only intended for demo and experimentation support, and many user management features are still missing. Also, the API client implementation does not yet support authentication at all.